### PR TITLE
Enable gzip compression by default

### DIFF
--- a/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
+++ b/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
@@ -1,11 +1,11 @@
 package org.visallo.web;
 
 import org.apache.catalina.Context;
-import org.apache.catalina.WebResource;
-import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.webresources.StandardRoot;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.apache.coyote.http11.Http11NioProtocol;
 import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.visallo.core.util.VisalloLogger;
@@ -15,6 +15,16 @@ import java.io.File;
 
 public class TomcatWebServer extends WebServer {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(TomcatWebServer.class);
+    private static final String COMPRESSABLE_MIME_TYPES = String.join(
+            "application/json,text/html,text/plain",
+            "text/xml",
+            "application/xhtml+xml",
+            "text/css",
+            "application/javascript",
+            "image/svg+xml",
+            "text/javascript"
+    );
+
     private Tomcat tomcat;
 
     public static void main(String[] args) throws Exception {
@@ -23,22 +33,12 @@ public class TomcatWebServer extends WebServer {
 
     @Override
     protected int run() throws Exception {
-        tomcat = new Tomcat();
-
         Connector httpsConnector = new Connector(Http11NioProtocol.class.getName());
-        httpsConnector.setPort(super.getHttpsPort());
-        httpsConnector.setSecure(true);
-        httpsConnector.setScheme("https");
-        httpsConnector.setAttribute("keystoreFile", super.getKeyStorePath());
-        httpsConnector.setAttribute("keystorePass", super.getKeyStorePassword());
-        httpsConnector.setAttribute("keystoreType", super.getKeyStoreType());
-        httpsConnector.setAttribute("truststoreFile", super.getTrustStorePath());
-        httpsConnector.setAttribute("truststorePass", super.getTrustStorePassword());
-        httpsConnector.setAttribute("truststoreType", super.getTrustStoreType());
-        httpsConnector.setAttribute("sslProtocol", "TLS");
-        httpsConnector.setAttribute("SSLEnabled", true);
-        setClientCertHandling(httpsConnector);
+        setupSslHandling(httpsConnector);
+        setupClientCertHandling(httpsConnector);
+        setupCompression(httpsConnector);
 
+        tomcat = new Tomcat();
         tomcat.setPort(super.getHttpPort());
         tomcat.getService().addConnector(httpsConnector);
 
@@ -48,10 +48,12 @@ public class TomcatWebServer extends WebServer {
         Context context = tomcat.addWebapp(this.getContextPath(), getWebAppDir().getAbsolutePath());
         context.setSessionTimeout(super.getSessionTimeout());
 
+        // don't scan classpath for web components to avoid benign log warnings
         StandardJarScanner jarScanner = new StandardJarScanner();
         jarScanner.setScanClassPath(false);
         context.setJarScanner(jarScanner);
 
+        // establish default caching settings to avoid benign log warnings
         StandardRoot webRoot = new StandardRoot(context);
         webRoot.setCacheMaxSize(100000);
         webRoot.setCachingAllowed(true);
@@ -71,16 +73,43 @@ public class TomcatWebServer extends WebServer {
         return tomcat;
     }
 
-    public void setClientCertHandling(Connector httpsConnector) {
+    private void setupSslHandling(Connector connector) {
+        connector.setPort(super.getHttpsPort());
+        connector.setSecure(true);
+        connector.setScheme("https");
+        connector.setAttribute("keystoreFile", super.getKeyStorePath());
+        connector.setAttribute("keystorePass", super.getKeyStorePassword());
+        connector.setAttribute("keystoreType", super.getKeyStoreType());
+        connector.setAttribute("truststoreFile", super.getTrustStorePath());
+        connector.setAttribute("truststorePass", super.getTrustStorePassword());
+        connector.setAttribute("truststoreType", super.getTrustStoreType());
+        connector.setAttribute("sslProtocol", "TLS");
+        connector.setAttribute("SSLEnabled", true);
+    }
+
+    public void setupClientCertHandling(Connector httpsConnector) {
         if (getRequireClientCert() && getWantClientCert()) {
             throw new IllegalArgumentException("Choose only one of --requireClientCert and --wantClientCert");
         }
+
+        String clientAuthSetting = "false";
         if (getRequireClientCert()) {
-            httpsConnector.setAttribute("clientAuth", "true");
+            clientAuthSetting = "true";
         } else if (getWantClientCert()) {
-            httpsConnector.setAttribute("clientAuth", "want");
-        } else {
-            httpsConnector.setAttribute("clientAuth", "false");
+            clientAuthSetting = "want";
+        }
+
+        httpsConnector.setAttribute("clientAuth", clientAuthSetting);
+        LOGGER.info("clientAuth certificate handling set to %s", clientAuthSetting);
+    }
+
+    public void setupCompression(Connector connector) {
+        ProtocolHandler handler = connector.getProtocolHandler();
+        if (handler instanceof AbstractHttp11Protocol) {
+            AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) handler;
+            protocol.setCompression("on");
+            protocol.setCompressableMimeType(COMPRESSABLE_MIME_TYPES);
+            LOGGER.info("compression set for mime types: %s", COMPRESSABLE_MIME_TYPES);
         }
     }
 }

--- a/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
+++ b/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
@@ -15,8 +15,10 @@ import java.io.File;
 
 public class TomcatWebServer extends WebServer {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(TomcatWebServer.class);
-    private static final String COMPRESSABLE_MIME_TYPES = String.join(
-            "application/json,text/html,text/plain",
+    private static final String COMPRESSABLE_MIME_TYPES = String.join(",",
+            "application/json",
+            "text/html",
+            "text/plain",
             "text/xml",
             "application/xhtml+xml",
             "text/css",


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions:
Verify that Chrome indicates that text-based content greater than 2048 bytes is compressed.

CHANGELOG
Changed: Turn on gzip compression for Tomcat by default