### PR TITLE
Fix product's updateViewable(3.1)

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/store/product/reducer.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/product/reducer.js
@@ -171,9 +171,7 @@ define(['updeep'], function(u) {
 
     function updateViewable(state, {workspaceId, vertices}) {
         const updateExtendedDataViewable = (product) => {
-            if (!product.extendedData || !product.extendedData.vertices) return product;
-
-            return u({
+            return u.if(product.extendedData && product.extendedData.vertices, {
                 extendedData: {
                     vertices: transformVertexData
                 }
@@ -195,7 +193,7 @@ define(['updeep'], function(u) {
             });
         };
 
-        return u({
+        return u.if(vertices, {
             workspaces: {
                 [workspaceId]: {
                     products: u.map(updateExtendedDataViewable)


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Diff panel wasn't able to load because this would error when there were no vertices with the ELEMENT_UPDATE payload.

Testing Instructions: Open the diff panel on a product that has edges and vertices

Points of Regression: Vertex visibility updates in work products

no changelog
