### PR TITLE
Fix detected objects form teardown(3.1)

### DIFF
--- a/web/war/src/main/webapp/js/detail/dropdowns/termForm/termForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/termForm/termForm.js
@@ -271,7 +271,7 @@ define([
                     self.trigger('termCreated', data);
                     self.trigger(document, 'loadEdges');
                     self.trigger('closeDropdown');
-                    _.defer(self.teardown.bind(self));
+                    self.teardown.bind(self);
                 })
                 .catch(this.requestFailure.bind(this))
         };
@@ -282,7 +282,7 @@ define([
                 .then(function(data) {
                     self.trigger(document, 'loadEdges');
                     self.trigger('closeDropdown');
-                    _.defer(self.teardown.bind(self));
+                    self.teardown.bind(self);
                 })
                 .catch(this.requestFailure.bind(this))
         };


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [ ] @joeybrk372 @rygim @jharwig @EvanOxfeld

CHANGELOG
Fixed: Resolving detected objects from an image would require you to refresh to see the updates in the element inspector.
