### PR TITLE
Fix vertex connection mouseup on edge(3.1)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -499,7 +499,9 @@ define([
             // TODO: show all selected objects if not on item
             if (cyTarget !== cy) {
                 const { pageX, pageY } = originalEvent;
-                this.props.onVertexMenu(originalEvent.target, cyTarget.id(), { x: pageX, y: pageY });
+                if (cyTarget.isNode()) {
+                    this.props.onVertexMenu(originalEvent.target, cyTarget.id(), { x: pageX, y: pageY });
+                }
             }
         },
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -471,6 +471,8 @@ define([
                     if (ctrlKey && upElement) {
                         this.onContextTap(event);
                     }
+                } else if (!upElement.isNode()) {
+                    this.cancelDraw();
                 } else {
                     this.setState({ draw: {...draw, toVertexId: upElement.id() } });
                     this.showConnectionPopover();


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Also: Fixed when context clicking an edge the vertex menu was showing up. This is only in the 3.1 pr since in master we have an edge menu.

Testing Instructions: ctrl+drag a vertex to start a connection and then release on an edge
 
CHANGELOG
Fixed: Trying to ctrl+drag a connection between concepts on the graph and letting go while over a relationship would prevent further interaction.
