### PR TITLE
Fix: vertex image upload metadata(3.1)

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexUploadImage.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexUploadImage.java
@@ -102,6 +102,8 @@ public class VertexUploadImage implements ParameterizedHandler {
 
         Metadata metadata = new Metadata();
         VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, visibilityTranslator.getDefaultVisibility());
+        VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(metadata, new Date(), visibilityTranslator.getDefaultVisibility());
+        VisalloProperties.MODIFIED_BY_METADATA.setMetadata(metadata, user.getUserId(), visibilityTranslator.getDefaultVisibility());
 
         String title = imageTitle(entityVertex);
         ElementBuilder<Vertex> artifactVertexBuilder = convertToArtifact(file, title, visibilityJson, metadata, user, visibility);


### PR DESCRIPTION
- [ ] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: After adding an image to a vertex, the image's history should show Created Image, as well as Title and Source property modifications by user.


CHANGELOG
Fixed: The properties automatically added to an image when you upload the image to another concept weren't showing the correct author and timestamp.
