### PR TITLE
Web: Submit search query on filter clear (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -377,10 +377,8 @@ define([
                         }
                     }
 
-                    var queryIsStarSearch = query === '*',
-                        hasQuery = query && query.length,
-                        validSearch = hasFilters ? hasQuery :
-                            (hadFilters && hasQuery && !queryIsStarSearch);
+                    const hasQuery = query && query.length;
+                    const validSearch = hasQuery && (hasFilters || hadFilters);
 
                     if (data.options && data.options.isScrubbing) {
                         self.triggerQueryUpdatedThrottled();

--- a/web/war/src/main/webapp/js/util/ontology/conceptSelect.js
+++ b/web/war/src/main/webapp/js/util/ontology/conceptSelect.js
@@ -38,6 +38,9 @@ define([
             this.on('clearSelectedConcept', this.onClearConcept);
             this.on('selectConceptId', this.onSelectConceptId);
             this.on('enableConcept', this.onEnableConcept);
+            this.on('change', {
+                fieldSelector: this.onChange
+            });
 
             this.setupTypeahead();
         });
@@ -76,6 +79,15 @@ define([
                 this.select('conceptSelector').attr('disabled', true);
             } else {
                 this.select('conceptSelector').removeAttr('disabled');
+            }
+        };
+
+        this.onChange = function(event, data) {
+            const value = $.trim(this.select('fieldSelector').val());
+            if (!value) {
+                this.trigger('conceptSelected', {
+                    concept: null
+                });
             }
         };
 

--- a/web/war/src/main/webapp/js/util/ontology/relationshipSelect.js
+++ b/web/war/src/main/webapp/js/util/ontology/relationshipSelect.js
@@ -33,6 +33,9 @@ define([
             });
             this.on('limitParentConceptId', this.onLimitParentConceptId);
             this.on('selectRelationshipId', this.onSetRelationshipId);
+            this.on('change', {
+                fieldSelector: this.onChange
+            });
 
             this.setupTypeahead();
         });
@@ -49,6 +52,15 @@ define([
         this.onLimitParentConceptId = function(event, data) {
             this.attr.limitParentConceptId = data.conceptId;
             this.transformRelationships();
+        };
+
+        this.onChange = function(event, data) {
+            const value = $.trim(this.select('fieldSelector').val());
+            if (!value) {
+                this.trigger('relationshipSelected', {
+                    relationship: null
+                });
+            }
         };
 
         this.setupTypeahead = function() {


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Triggers `conceptSelected` or `relationshipSelected` on clearing the concept or relationship filter respectively. To account for resubmitting star searches after the filter was cleared, Search component triggers `querysubmit` if the previous query included a filter.

Testing Instructions: Verify that both regular and star search queries are resubmitted when the concept and the relationship filters are cleared. While within the concept or relationship dropdown, clearing the filter requires pressing enter or clicking outside of the dropdown, otherwise `All Concepts` or `All Relationship Types` will not be selected.

Points of Regression: Other search filter behavior

CHANGELOG
Fixed: Search panel resubmits search queries when the concept or relationship filter is cleared without pressing enter in the search field.
