### PR TITLE
Fix ontology repository to return parent properties (#936)

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -468,7 +468,10 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
         if (parentConceptVertex == null) {
             return null;
         }
-        return createConcept(parentConceptVertex);
+
+        String parentIri = OntologyProperties.ONTOLOGY_TITLE.getPropertyValue(parentConceptVertex);
+
+        return getConceptByIRI(parentIri);
     }
 
     private List<Concept> toConcepts(Iterable<Vertex> vertices) {

--- a/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepositoryTest.java
+++ b/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepositoryTest.java
@@ -19,6 +19,7 @@ import org.visallo.core.model.lock.LockRepository;
 import org.visallo.core.model.lock.NonLockingLockRepository;
 import org.visallo.core.model.ontology.Concept;
 import org.visallo.core.model.ontology.OntologyProperty;
+import org.visallo.core.model.ontology.OntologyRepository;
 import org.visallo.core.model.ontology.Relationship;
 import org.visallo.core.model.termMention.TermMentionRepository;
 import org.visallo.core.model.user.GraphAuthorizationRepository;
@@ -43,12 +44,18 @@ public class VertexiumOntologyRepositoryTest {
     private static final String TEST_CHANGED_OWL = "test_changed.owl";
     private static final String TEST01_OWL = "test01.owl";
     private static final String TEST_IRI = "http://visallo.org/test";
+
+    private static final String TEST_HIERARCHY_IRI = "http://visallo.org/testhierarchy";
+    private static final String TEST_HIERARCHY_OWL = "test_hierarchy.owl";
+
     private static final String TEST01_IRI = "http://visallo.org/test01";
     private VertexiumOntologyRepository ontologyRepository;
     private Authorizations authorizations;
     private Graph graph;
     private GraphAuthorizationRepository graphAuthorizationRepository;
     private LockRepository lockRepository;
+    private GraphRepository graphRepository;
+
     @Mock
     private Configuration configuration;
     @Mock
@@ -63,32 +70,12 @@ public class VertexiumOntologyRepositoryTest {
         graphAuthorizationRepository = new InMemoryGraphAuthorizationRepository();
         lockRepository = new NonLockingLockRepository();
         VisibilityTranslator visibilityTranslator = new DirectVisibilityTranslator();
-        GraphRepository graphRepository = new GraphRepository(graph, visibilityTranslator, termMentionRepository, workQueueRepository);
-        ontologyRepository = new VertexiumOntologyRepository(
-                graph,
-                graphRepository,
-                configuration,
-                graphAuthorizationRepository,
-                lockRepository
-        ) {
-            @Override
-            public void loadOntologies(Configuration config, Authorizations authorizations) throws Exception {
-                Concept rootConcept = getOrCreateConcept(null, ROOT_CONCEPT_IRI, "root", null);
-                getOrCreateConcept(rootConcept, ENTITY_CONCEPT_IRI, "thing", null);
-                clearCache();
-                return;
-            }
-        };
-
-        File testOwl = new File(VertexiumOntologyRepositoryTest.class.getResource(TEST_OWL).toURI());
-        ontologyRepository.importFile(testOwl, IRI.create(TEST_IRI), authorizations);
-        validateTestOwlRelationship();
-        validateTestOwlConcepts(1, 2);
-        validateTestOwlProperties();
+        graphRepository = new GraphRepository(graph, visibilityTranslator, termMentionRepository, workQueueRepository);
     }
 
     @Test
     public void changingDisplayAnnotationsShouldSucceed() throws Exception {
+        loadTestOwlFile();
         File changedOwl = new File(VertexiumOntologyRepositoryTest.class.getResource(TEST_CHANGED_OWL).toURI());
 
         ontologyRepository.importFile(changedOwl, IRI.create(TEST_IRI), authorizations);
@@ -99,7 +86,17 @@ public class VertexiumOntologyRepositoryTest {
     }
 
     @Test
+    public void testGettingParentConceptReturnsParentProperties() throws Exception {
+        loadHierarchyOwlFile();
+        Concept concept = ontologyRepository.getConceptByIRI(TEST_HIERARCHY_IRI + "#person");
+        Concept parentConcept = ontologyRepository.getParentConcept(concept);
+        assertEquals(1, parentConcept.getProperties().size());
+    }
+
+
+    @Test
     public void dependenciesBetweenOntologyFilesShouldNotChangeParentProperties() throws Exception {
+        loadTestOwlFile();
         File changedOwl = new File(VertexiumOntologyRepositoryTest.class.getResource(TEST01_OWL).toURI());
 
         ontologyRepository.importFile(changedOwl, IRI.create(TEST01_IRI), authorizations);
@@ -110,10 +107,11 @@ public class VertexiumOntologyRepositoryTest {
         OntologyProperty aliasProperty = ontologyRepository.getPropertyByIRI(TEST01_IRI + "#alias");
         Concept person = ontologyRepository.getConceptByIRI(TEST_IRI + "#person");
         assertTrue(person.getProperties()
-                           .stream()
-                           .anyMatch(p -> p.getIri().equals(aliasProperty.getIri()))
+                .stream()
+                .anyMatch(p -> p.getIri().equals(aliasProperty.getIri()))
         );
     }
+
 
     private void validateTestOwlRelationship() {
         Relationship relationship = ontologyRepository.getRelationshipByIRI(TEST_IRI + "#personKnowsPerson");
@@ -136,10 +134,10 @@ public class VertexiumOntologyRepositoryTest {
         assertEquals("Name", nameProperty.getDisplayName());
         assertEquals(PropertyType.STRING, nameProperty.getDataType());
         assertEquals("_.compact([\n" +
-                             "            dependentProp('http://visallo.org/test#firstName'),\n" +
-                             "            dependentProp('http://visallo.org/test#middleName'),\n" +
-                             "            dependentProp('http://visallo.org/test#lastName')\n" +
-                             "            ]).join(', ')", nameProperty.getDisplayFormula().trim());
+                "            dependentProp('http://visallo.org/test#firstName'),\n" +
+                "            dependentProp('http://visallo.org/test#middleName'),\n" +
+                "            dependentProp('http://visallo.org/test#lastName')\n" +
+                "            ]).join(', ')", nameProperty.getDisplayFormula().trim());
         ImmutableList<String> dependentPropertyIris = nameProperty.getDependentPropertyIris();
         assertEquals(3, dependentPropertyIris.size());
         assertTrue(dependentPropertyIris.contains("http://visallo.org/test#firstName"));
@@ -164,8 +162,8 @@ public class VertexiumOntologyRepositoryTest {
 
         Concept person = ontologyRepository.getConceptByIRI(TEST_IRI + "#person");
         assertTrue(person.getProperties()
-                           .stream()
-                           .anyMatch(p -> p.getIri().equals(nameProperty.getIri()))
+                .stream()
+                .anyMatch(p -> p.getIri().equals(nameProperty.getIri()))
         );
 
         OntologyProperty firstMetProperty = ontologyRepository.getPropertyByIRI(TEST_IRI + "#firstMet");
@@ -174,8 +172,8 @@ public class VertexiumOntologyRepositoryTest {
 
         Relationship relationship = ontologyRepository.getRelationshipByIRI(TEST_IRI + "#personKnowsPerson");
         assertTrue(relationship.getProperties()
-                           .stream()
-                           .anyMatch(p -> p.getIri().equals(firstMetProperty.getIri()))
+                .stream()
+                .anyMatch(p -> p.getIri().equals(firstMetProperty.getIri()))
         );
     }
 
@@ -247,9 +245,9 @@ public class VertexiumOntologyRepositoryTest {
         assertEquals("http://visallo.org/test#name", nameProperty.getDisplayName());
         assertEquals(PropertyType.STRING, nameProperty.getDataType());
         assertEquals("_.compact([\n" +
-                             "            dependentProp('http://visallo.org/test#firstName'),\n" +
-                             "            dependentProp('http://visallo.org/test#lastName')\n" +
-                             "            ]).join(', ')", nameProperty.getDisplayFormula().trim());
+                "            dependentProp('http://visallo.org/test#firstName'),\n" +
+                "            dependentProp('http://visallo.org/test#lastName')\n" +
+                "            ]).join(', ')", nameProperty.getDisplayFormula().trim());
         ImmutableList<String> dependentPropertyIris = nameProperty.getDependentPropertyIris();
         assertEquals(3, dependentPropertyIris.size());
         assertTrue(dependentPropertyIris.contains("http://visallo.org/test#firstName"));
@@ -276,9 +274,43 @@ public class VertexiumOntologyRepositoryTest {
 
         Relationship relationship = ontologyRepository.getRelationshipByIRI(TEST_IRI + "#personKnowsPerson");
         assertTrue(relationship.getProperties()
-                           .stream()
-                           .anyMatch(p -> p.getIri().equals(firstMetProperty.getIri()))
+                .stream()
+                .anyMatch(p -> p.getIri().equals(firstMetProperty.getIri()))
         );
+    }
+
+    private void loadTestOwlFile() throws Exception {
+        createTestOntologyRepository(TEST_OWL, TEST_IRI);
+        validateTestOwlRelationship();
+        validateTestOwlConcepts(1, 2);
+        validateTestOwlProperties();
+    }
+
+
+    private void loadHierarchyOwlFile() throws Exception {
+        createTestOntologyRepository(TEST_HIERARCHY_OWL, TEST_HIERARCHY_IRI);
+    }
+
+    private VertexiumOntologyRepository createTestOntologyRepository(String owlFileResourcePath, String iri) throws Exception {
+        ontologyRepository = new VertexiumOntologyRepository(
+                graph,
+                graphRepository,
+                configuration,
+                graphAuthorizationRepository,
+                lockRepository
+        ) {
+            @Override
+            public void loadOntologies(Configuration config, Authorizations authorizations) throws Exception {
+                Concept rootConcept = getOrCreateConcept(null, ROOT_CONCEPT_IRI, "root", null);
+                getOrCreateConcept(rootConcept, ENTITY_CONCEPT_IRI, "thing", null);
+                clearCache();
+            }
+        };
+
+        File testOwl = new File(VertexiumOntologyRepositoryTest.class.getResource(owlFileResourcePath).toURI());
+        ontologyRepository.importFile(testOwl, IRI.create(iri), authorizations);
+
+        return ontologyRepository;
     }
 }
 

--- a/core/plugins/model-vertexium/src/test/resources/org/visallo/vertexium/model/ontology/test_hierarchy.owl
+++ b/core/plugins/model-vertexium/src/test/resources/org/visallo/vertexium/model/ontology/test_hierarchy.owl
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY visallo "http://visallo.org#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF xmlns="http://visallo.org/testhierarchy#"
+     xml:base="http://visallo.org/test"
+     xmlns:visallo="http://visallo.org#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://visallo.org/test"/>
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <!-- http://visallo.org/testhierarchy#personKnowsPerson -->
+
+    <owl:ObjectProperty rdf:about="http://visallo.org/testhierarchy#personKnowsPerson">
+        <rdfs:label xml:lang="en">Knows</rdfs:label>
+        <visallo:timeFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#firstMet&apos;) || &apos;&apos;</visallo:timeFormula>
+        <rdfs:range rdf:resource="http://visallo.org/testhierarchy#person"/>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#person"/>
+    </owl:ObjectProperty>
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+    <!-- http://visallo.org/testhierarchy#name -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#name">
+        <rdfs:label xml:lang="en">Name</rdfs:label>
+        <visallo:textIndexHints>FULL_TEXT,EXACT_MATCH</visallo:textIndexHints>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#person"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+         <visallo:displayFormula>
+            _.compact([
+            dependentProp(&apos;http://visallo.org/testhierarchy#firstName&apos;),
+            dependentProp(&apos;http://visallo.org/testhierarchy#middleName&apos;),
+            dependentProp(&apos;http://visallo.org/testhierarchy#lastName&apos;)
+            ]).join(&apos;, &apos;)
+        </visallo:displayFormula>
+        <visallo:dependentPropertyIris>[
+            &quot;http://visallo.org/testhierarchy#firstName&quot;,
+            &quot;http://visallo.org/testhierarchy#middleName&quot;,
+            &quot;http://visallo.org/testhierarchy#lastName&quot;
+            ]</visallo:dependentPropertyIris>
+        <visallo:intent>test3</visallo:intent>
+        <visallo:validationFormula>dependentProp(&apos;http://visallo.org/testhierarchy#lastName&apos;) &amp;&amp; dependentProp(&apos;http://visallo.org/testhierarchy#firstName&apos;)</visallo:validationFormula>
+        <visallo:propertyGroup xml:lang="en">Personal Information</visallo:propertyGroup>
+        <visallo:displayType xml:lang="en">test</visallo:displayType>
+        <visallo:addable rdf:datatype="&xsd;boolean">false</visallo:addable>
+        <visallo:updateable rdf:datatype="&xsd;boolean">false</visallo:updateable>
+        <visallo:deleteable rdf:datatype="&xsd;boolean">false</visallo:deleteable>
+        <visallo:possibleValues xml:lang="en">
+        {
+            &quot;T1&quot;: &quot;test 1&quot;,
+            &quot;T2&quot;: &quot;test 2&quot;
+        }
+        </visallo:possibleValues>
+    </owl:DatatypeProperty>
+
+
+    <!-- http://visallo.org/testhierarchy#firstMet -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#firstMet">
+        <rdfs:label xml:lang="en">First Met</rdfs:label>
+        <visallo:objectPropertyDomain rdf:resource="http://visallo.org/testhierarchy#personKnowsPerson"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#contacted">
+        <rdfs:label xml:lang="en">Contacted</rdfs:label>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#contact"/>
+        <rdfs:range rdf:resource="&xsd;boolean"/>
+    </owl:DatatypeProperty>
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+    <!-- http://visallo.org/testhierarchy#contact -->
+
+    <owl:Class rdf:about="http://visallo.org/testhierarchy#contact">
+        <rdfs:label xml:lang="en">Contact</rdfs:label>
+        <visallo:color xml:lang="en">rgb(149, 138, 218)</visallo:color>
+        <visallo:displayType xml:lang="en">test</visallo:displayType>
+    </owl:Class>
+
+
+
+    <!-- http://visallo.org/testhierarchy#person -->
+
+    <owl:Class rdf:about="http://visallo.org/testhierarchy#person">
+        <rdfs:label xml:lang="en">Person</rdfs:label>
+        <visallo:intent>person</visallo:intent>
+        <visallo:timeFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#birthDate&apos;) || &apos;&apos;</visallo:timeFormula>
+        <visallo:titleFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#name&apos;) || &apos;&apos;</visallo:titleFormula>
+        <visallo:intent>face</visallo:intent>
+        <visallo:glyphIconFileName xml:lang="en">glyphicons_003_user@2x.png</visallo:glyphIconFileName>
+        <visallo:color xml:lang="en">rgb(28, 137, 28)</visallo:color>
+        <rdfs:subClassOf rdf:resource="http://visallo.org/testhierarchy#contact"/>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+


### PR DESCRIPTION
This PR is pulling back a fix from master back to the release-3.1 branch so that the branch can be tested in QA in the same way we currently test master. Currently this is a blocker for how we load test data into the system on this branch.

Previous PR: https://github.com/visallo/visallo/pull/936

* Fix ontology repository to return parent properties

Whenever the the vertexium ontology repository would query for a parent concept, it would not return the properties that were associated with that concept. This is important when checking inheritance in the case of the generated ontology code, and would cause the IngestRepository to start throwing failures because it tries to prevent invalid data from going into Visallo. By returning a more fully inflated parent concept the VertexiumOntologyRepository not only matches what is expected, but now works the same as in in memory implementation

* add unit tests for vertexium parent concept pulling back properties

* use parent iri from vertex to find parent concept

Conflicts:
	core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepositoryTest.java

- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions:
(These instructions may not be reasonable to actually test)

Generate code for entities of ontology that has two concepts, one parent and one child, with a property on the parent.
Ensure that you are using the VertexiumOntologyRepository
Try and ingest the entities using the generated code by setting a property on the child-concept that is in on the parent concept. Use the IngestRepository to save the created data. There will be no validation errors.

Points of Regression:
N/A

CHANGELOG
Fixed: VertexiumOntologyRepository returns properties on the parent concept when returning the parent concept
