### PR TITLE
Web: Submit search query on extension filter clear (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -545,6 +545,7 @@ define([
             })
             this.disableMatchEdges = false;
             this.setMatchType(this.matchType);
+            this.notifyOfFilters();
         };
 
         this.createNewRowIfNeeded = function() {


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Triggers `filterchange` when an extension filter, such as search related, is removed. Depends on #975.

CHANGELOG
Fixed: Search panel resubmits search queries when an extension filter is cleared without pressing enter in the search field.
