### PR TITLE
Fix sharing dropdown overlap (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/workspaces/form/shareRow.ejs
+++ b/web/war/src/main/webapp/js/workspaces/form/shareRow.ejs
@@ -1,8 +1,10 @@
 <li class="user-row" data-user-id="<%= user.userId %>"
-><span class="badge permissions"
+>
+  <span class="user-displayname"><%= user.displayName %></span>
+  <span class="badge permissions"
        data-access="<%= user.access.toUpperCase() %>"
        style="<%= editable ? '' : 'cursor:default' %>"
-       ><%= user.permissionLabel %> <% if (editable) { %><span class="caret"></span><% } %></span><%= user.displayName %>
+       ><%= user.permissionLabel %> <% if (editable) { %><span class="caret"></span><% } %></span>
   <% if (user.displayName.toLowerCase() !== (user.email || user.userName).toLowerCase()) { %>
   <div class="subtitle"><%= user.email || user.userName %></div>
   <% } %>

--- a/web/war/src/main/webapp/less/workspaces/workspaces.less
+++ b/web/war/src/main/webapp/less/workspaces/workspaces.less
@@ -119,6 +119,7 @@ li {
   .badge {
     cursor: pointer;
     margin: 0.25em 0 0 0.5em;
+    flex: 0 0 auto;
   }
 
   .popover {
@@ -182,13 +183,17 @@ li {
   }
 
   .share-list li.user-row {
+    display: flex;
     margin: 0.5em 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     .subtitle {
       font-size: 90%;
       color: #555;
+    }
+    .user-displayname {
+      flex: 1 1 auto;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .user-status {
       top: 1.5ex;


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [ ] @joeybrk372 @rygim @jharwig @EvanOxfeld

Converts case shareRows to flexbox. Will submit a pull request to master when approved.

Testing Instructions: Verify that the user name displays with an ellipsis when necessary and the permission dropdown does not overlap at various edit case panel widths in the supported browsers.

Points of Regression: None. Changes isolated to the edit case form.

CHANGELOG
Fixed: Case sharing username and permission dropdown overlap issues
