### PR TITLE
add tomcat dependency into maven profile build 'desktop' (release-3.1)

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -110,6 +110,7 @@
         <pdfbox.version>2.0.1</pdfbox.version>
         <apache.poi.version>3.15-beta1</apache.poi.version>
         <aws-java-sdk.version>1.11.63</aws-java-sdk.version>
+        <tomcat.version>8.5.6</tomcat.version>
 
         <!-- Test Dependency Versions -->
         <junit.version>4.11</junit.version>

--- a/web/war/pom.xml
+++ b/web/war/pom.xml
@@ -186,5 +186,20 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>desktop</id>
+            <dependencies>
+              <dependency>
+                  <groupId>org.apache.tomcat.embed</groupId>
+                  <artifactId>tomcat-embed-core</artifactId>
+                  <version>${tomcat.version}</version>
+              </dependency>
+              <dependency>
+                  <groupId>org.apache.tomcat.embed</groupId>
+                  <artifactId>tomcat-embed-websocket</artifactId>
+                  <version>${tomcat.version}</version>
+              </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
After changing to tomcat as our web server, there were some service loaders that were not loaded and then made available to Visallo when creating an embedded visallo instance. This adds those into the WEB-INF/lib folder so that they are available at runtime

- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Create a desktop jar

Points of Regression: None

CHANGELOG
Added: Tomcat dependencies are inside of war when running with desktop profile
