### PR TITLE
Fix ontology repository to return parent properties (#936) (2.1)

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -475,7 +475,10 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
         if (parentConceptVertex == null) {
             return null;
         }
-        return createConcept(parentConceptVertex);
+
+        String parentIri = OntologyProperties.ONTOLOGY_TITLE.getPropertyValue(parentConceptVertex);
+
+        return getConceptByIRI(parentIri);
     }
 
     private List<Concept> toConcepts(Iterable<Vertex> vertices) {

--- a/core/plugins/model-vertexium/src/test/resources/org/visallo/vertexium/model/ontology/test_hierarchy.owl
+++ b/core/plugins/model-vertexium/src/test/resources/org/visallo/vertexium/model/ontology/test_hierarchy.owl
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY visallo "http://visallo.org#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF xmlns="http://visallo.org/testhierarchy#"
+     xml:base="http://visallo.org/test"
+     xmlns:visallo="http://visallo.org#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://visallo.org/test"/>
+
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <!-- http://visallo.org/testhierarchy#personKnowsPerson -->
+
+    <owl:ObjectProperty rdf:about="http://visallo.org/testhierarchy#personKnowsPerson">
+        <rdfs:label xml:lang="en">Knows</rdfs:label>
+        <visallo:timeFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#firstMet&apos;) || &apos;&apos;</visallo:timeFormula>
+        <rdfs:range rdf:resource="http://visallo.org/testhierarchy#person"/>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#person"/>
+    </owl:ObjectProperty>
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+    <!-- http://visallo.org/testhierarchy#name -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#name">
+        <rdfs:label xml:lang="en">Name</rdfs:label>
+        <visallo:textIndexHints>FULL_TEXT,EXACT_MATCH</visallo:textIndexHints>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#person"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+         <visallo:displayFormula>
+            _.compact([
+            dependentProp(&apos;http://visallo.org/testhierarchy#firstName&apos;),
+            dependentProp(&apos;http://visallo.org/testhierarchy#middleName&apos;),
+            dependentProp(&apos;http://visallo.org/testhierarchy#lastName&apos;)
+            ]).join(&apos;, &apos;)
+        </visallo:displayFormula>
+        <visallo:dependentPropertyIris>[
+            &quot;http://visallo.org/testhierarchy#firstName&quot;,
+            &quot;http://visallo.org/testhierarchy#middleName&quot;,
+            &quot;http://visallo.org/testhierarchy#lastName&quot;
+            ]</visallo:dependentPropertyIris>
+        <visallo:intent>test3</visallo:intent>
+        <visallo:validationFormula>dependentProp(&apos;http://visallo.org/testhierarchy#lastName&apos;) &amp;&amp; dependentProp(&apos;http://visallo.org/testhierarchy#firstName&apos;)</visallo:validationFormula>
+        <visallo:propertyGroup xml:lang="en">Personal Information</visallo:propertyGroup>
+        <visallo:displayType xml:lang="en">test</visallo:displayType>
+        <visallo:addable rdf:datatype="&xsd;boolean">false</visallo:addable>
+        <visallo:updateable rdf:datatype="&xsd;boolean">false</visallo:updateable>
+        <visallo:deleteable rdf:datatype="&xsd;boolean">false</visallo:deleteable>
+        <visallo:possibleValues xml:lang="en">
+        {
+            &quot;T1&quot;: &quot;test 1&quot;,
+            &quot;T2&quot;: &quot;test 2&quot;
+        }
+        </visallo:possibleValues>
+    </owl:DatatypeProperty>
+
+
+    <!-- http://visallo.org/testhierarchy#firstMet -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#firstMet">
+        <rdfs:label xml:lang="en">First Met</rdfs:label>
+        <visallo:objectPropertyDomain rdf:resource="http://visallo.org/testhierarchy#personKnowsPerson"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/testhierarchy#contacted">
+        <rdfs:label xml:lang="en">Contacted</rdfs:label>
+        <rdfs:domain rdf:resource="http://visallo.org/testhierarchy#contact"/>
+        <rdfs:range rdf:resource="&xsd;boolean"/>
+    </owl:DatatypeProperty>
+
+    <!--
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+
+    <!-- http://visallo.org/testhierarchy#contact -->
+
+    <owl:Class rdf:about="http://visallo.org/testhierarchy#contact">
+        <rdfs:label xml:lang="en">Contact</rdfs:label>
+        <visallo:color xml:lang="en">rgb(149, 138, 218)</visallo:color>
+        <visallo:displayType xml:lang="en">test</visallo:displayType>
+    </owl:Class>
+
+
+
+    <!-- http://visallo.org/testhierarchy#person -->
+
+    <owl:Class rdf:about="http://visallo.org/testhierarchy#person">
+        <rdfs:label xml:lang="en">Person</rdfs:label>
+        <visallo:intent>person</visallo:intent>
+        <visallo:timeFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#birthDate&apos;) || &apos;&apos;</visallo:timeFormula>
+        <visallo:titleFormula xml:lang="en">prop(&apos;http://visallo.org/testhierarchy#name&apos;) || &apos;&apos;</visallo:titleFormula>
+        <visallo:intent>face</visallo:intent>
+        <visallo:glyphIconFileName xml:lang="en">glyphicons_003_user@2x.png</visallo:glyphIconFileName>
+        <visallo:color xml:lang="en">rgb(28, 137, 28)</visallo:color>
+        <rdfs:subClassOf rdf:resource="http://visallo.org/testhierarchy#contact"/>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+


### PR DESCRIPTION
Backporting fix from https://github.com/visallo/visallo/pull/936 to release-2.1

Whenever the the vertexium ontology repository would query for a parent concept, it would not return the properties that were associated with that concept. This is important when checking inheritance in the case of the generated ontology code, and would cause the IngestRepository to start throwing failures because it tries to prevent invalid data from going into Visallo. By returning a more fully inflated parent concept the VertexiumOntologyRepository not only matches what is expected, but now works the same as in in memory implementation

- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions:
(These instructions may not be reasonable to actually test)

Generate code for entities of ontology that has two concepts, one parent and one child, with a property on the parent.
Ensure that you are using the VertexiumOntologyRepository
Try and ingest the entities using the generated code by setting a property on the child-concept that is in on the parent concept. Use the IngestRepository to save the created data. There will be no validation errors.

Points of Regression:
N/A

CHANGELOG
Fixed: VertexiumOntologyRepository returns properties on the parent concept when returning the parent concept