### PR TITLE
Fix IE indeterminate checkbox(3.1)

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/columnConfigPopover.js
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/columnConfigPopover.js
@@ -82,12 +82,14 @@ define([
         };
 
         this.updateSelectAllCheckbox = function() {
+            const selectAllCheckbox = $(this.attr.selectAllSelector, this.popover);
             if (this.selectedColumnIris.length === 0) {
-                $(this.attr.selectAllSelector, this.popover).prop('checked', false).prop('indeterminate', false);
+                selectAllCheckbox.prop('checked', false).prop('indeterminate', false);
             } else if (this.selectedColumnIris.length === $(this.attr.inputSelector, this.popover).size()) {
-                $(this.attr.selectAllSelector, this.popover).prop('checked', true).prop('indeterminate', false);
+                selectAllCheckbox.prop('checked', true).prop('indeterminate', false);
             } else {
-                $(this.attr.selectAllSelector, this.popover).prop('checked', true).prop('indeterminate', true);
+                selectAllCheckbox.prop('checked', true).prop('indeterminate', true)
+                    .off('click').one('click', (event) => { this.onSelectAllChange(event) });
             }
         }
     }


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

CHANGELOG
Fixed: In IE, clicking the display all columns checkbox in the table configuration would not update on the first click if some columns were displayed and some were not(checkbox was indeterminate).
