### PR TITLE
Search interface improvements (3.1)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
@@ -133,7 +133,11 @@ public interface OntologyRepository {
 
     void addConceptTypeFilterToQuery(Query query, String conceptTypeIri, boolean includeChildNodes);
 
+    void addConceptTypeFilterToQuery(Query query, String[] conceptTypeIri, boolean[] includeChildNodes);
+
     void addEdgeLabelFilterToQuery(Query query, String edgeLabel, boolean includeChildNodes);
+
+    void addEdgeLabelFilterToQuery(Query query, String[] edgeLabel, boolean[] includeChildNodes);
 
     void updatePropertyDependentIris(OntologyProperty property, Collection<String> dependentPropertyIris);
 

--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
@@ -9,6 +9,7 @@ import org.vertexium.Authorizations;
 import org.vertexium.query.Query;
 import org.visallo.core.model.properties.types.VisalloProperty;
 import org.visallo.core.security.VisalloVisibility;
+import org.visallo.web.clientapi.model.ClientApiObject;
 import org.visallo.web.clientapi.model.ClientApiOntology;
 
 import java.io.File;
@@ -133,13 +134,27 @@ public interface OntologyRepository {
 
     void addConceptTypeFilterToQuery(Query query, String conceptTypeIri, boolean includeChildNodes);
 
-    void addConceptTypeFilterToQuery(Query query, String[] conceptTypeIri, boolean[] includeChildNodes);
+    void addConceptTypeFilterToQuery(Query query, Collection<ElementTypeFilter> filters);
 
     void addEdgeLabelFilterToQuery(Query query, String edgeLabel, boolean includeChildNodes);
 
-    void addEdgeLabelFilterToQuery(Query query, String[] edgeLabel, boolean[] includeChildNodes);
+    void addEdgeLabelFilterToQuery(Query query, Collection<ElementTypeFilter> filters);
 
     void updatePropertyDependentIris(OntologyProperty property, Collection<String> dependentPropertyIris);
 
     void updatePropertyDomainIris(OntologyProperty property, Set<String> domainIris);
+
+    class ElementTypeFilter implements ClientApiObject {
+        public String iri;
+        public boolean includeChildNodes;
+
+        public ElementTypeFilter() {
+
+        }
+
+        public ElementTypeFilter(String iri, boolean includeChildNodes) {
+            this.iri = iri;
+            this.includeChildNodes = includeChildNodes;
+        }
+    }
 }

--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -51,7 +51,9 @@ import java.lang.reflect.Constructor;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class OntologyRepositoryBase implements OntologyRepository {
@@ -1266,46 +1268,63 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
 
     @Override
     public void addConceptTypeFilterToQuery(Query query, String conceptTypeIri, boolean includeChildNodes) {
-        checkNotNull(query, "query cannot be null");
         checkNotNull(conceptTypeIri, "conceptTypeIri cannot be null");
+        addConceptTypeFilterToQuery(query, new String[] { conceptTypeIri }, new boolean[] { includeChildNodes });
+    }
 
-        Concept concept = getConceptByIRI(conceptTypeIri);
-        checkNotNull(concept, "Could not find concept with IRI: " + conceptTypeIri);
-        if (includeChildNodes) {
-            Set<Concept> childConcepts = getConceptAndAllChildren(concept);
-            if (childConcepts.size() > 0) {
-                String[] conceptIds = new String[childConcepts.size()];
-                int count = 0;
-                for (Concept c : childConcepts) {
-                    conceptIds[count] = c.getIRI();
-                    count++;
-                }
-                query.has(VisalloProperties.CONCEPT_TYPE.getPropertyName(), Contains.IN, conceptIds);
+    @Override
+    public void addConceptTypeFilterToQuery(Query query, String[] conceptTypeIri, boolean[] includeChildNodes) {
+        checkNotNull(query, "query cannot be null");
+        checkArgument(conceptTypeIri.length == includeChildNodes.length, "Must include same size arrays");
+        if (conceptTypeIri.length == 0) return;
+        Set<String> conceptIds = new HashSet<>(conceptTypeIri.length);
+
+        int index = 0;
+        for (String iri : conceptTypeIri) {
+            Concept concept = getConceptByIRI(iri);
+            checkNotNull(concept, "Could not find concept with IRI: " + conceptTypeIri);
+
+            conceptIds.add(concept.getIRI());
+
+            if (includeChildNodes[index]) {
+                Set<Concept> childConcepts = getConceptAndAllChildren(concept);
+                conceptIds.addAll(childConcepts.stream().map(Concept::getIRI).collect(Collectors.toSet()));
             }
-        } else {
-            query.has(VisalloProperties.CONCEPT_TYPE.getPropertyName(), conceptTypeIri);
+
+            index++;
         }
+
+        query.has(VisalloProperties.CONCEPT_TYPE.getPropertyName(), Contains.IN, conceptIds);
     }
 
     @Override
     public void addEdgeLabelFilterToQuery(Query query, String edgeLabel, boolean includeChildNodes) {
-        checkNotNull(query, "query cannot be null");
         checkNotNull(edgeLabel, "edgeLabel cannot be null");
+        addEdgeLabelFilterToQuery(query, new String[] { edgeLabel }, new boolean[] { includeChildNodes });
+    }
 
-        Relationship relationship = getRelationshipByIRI(edgeLabel);
-        if (includeChildNodes) {
-            Set<Relationship> childRelationships = getRelationshipAndAllChildren(relationship);
-            if (childRelationships.size() > 0) {
-                String[] relationshipIds = new String[childRelationships.size()];
-                int count = 0;
-                for (Relationship r : childRelationships) {
-                    relationshipIds[count] = r.getIRI();
-                    count++;
-                }
-                query.hasEdgeLabel(relationshipIds);
+    @Override
+    public void addEdgeLabelFilterToQuery(Query query, String[] edgeLabel, boolean[] includeChildNodes) {
+        checkNotNull(query, "query cannot be null");
+        checkArgument(edgeLabel.length == includeChildNodes.length, "Must include same size arrays");
+        if (edgeLabel.length == 0) return;
+        Set<String> edgeIds = new HashSet<>(edgeLabel.length);
+
+        int index = 0;
+        for (String iri : edgeLabel) {
+            Relationship relationship = getRelationshipByIRI(iri);
+            checkNotNull(relationship, "Could not find edge with IRI: " + edgeLabel);
+
+            edgeIds.add(relationship.getIRI());
+
+            if (includeChildNodes[index]) {
+                Set<Relationship> childRelations = getRelationshipAndAllChildren(relationship);
+                edgeIds.addAll(childRelations.stream().map(Relationship::getIRI).collect(Collectors.toSet()));
             }
-        } else {
-            query.hasEdgeLabel(edgeLabel);
+
+            index++;
         }
+
+        query.hasEdgeLabel(edgeIds);
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -17,6 +17,7 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.JSONUtil;
 import org.visallo.web.clientapi.model.PropertyType;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.text.ParseException;
 import java.util.*;
@@ -217,20 +218,58 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
     protected abstract QueryAndData getQuery(SearchOptions searchOptions, Authorizations authorizations);
 
     protected void applyConceptTypeFilterToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
-        final String conceptType = searchOptions.getOptionalParameter("conceptType", String.class);
-        final Boolean includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", Boolean.class);
         Query query = queryAndData.getQuery();
-        if (conceptType != null) {
-            ontologyRepository.addConceptTypeFilterToQuery(query, conceptType, (includeChildNodes == null || includeChildNodes));
+
+        String conceptTypes = searchOptions.getOptionalParameter("conceptTypes", String.class);
+
+        if (conceptTypes == null) {
+            // Try legacy conceptType parameter
+            String conceptType = searchOptions.getOptionalParameter("conceptType", String.class);
+            if (conceptType != null) {
+                final Boolean includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", Boolean.class);
+                ontologyRepository.addConceptTypeFilterToQuery(query, conceptType, (includeChildNodes == null || includeChildNodes));
+            }
+        } else {
+            JSONArray types = new JSONArray(conceptTypes);
+            if (types.length() > 0) {
+                String[] iris = new String[types.length()];
+                boolean[] includes = new boolean[types.length()];
+
+                for (int i = 0; i < types.length(); i++) {
+                    JSONObject type = (JSONObject) types.get(i);
+                    iris[i] = type.getString("iri");
+                    includes[i] = type.optBoolean("includeChildNodes", false);
+                }
+                ontologyRepository.addConceptTypeFilterToQuery(query, iris, includes);
+            }
         }
     }
 
     protected void applyEdgeLabelFilterToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
-        final String edgeLabel = searchOptions.getOptionalParameter("edgeLabel", String.class);
-        final Boolean includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", Boolean.class);
         Query query = queryAndData.getQuery();
-        if (edgeLabel != null) {
-            ontologyRepository.addEdgeLabelFilterToQuery(query, edgeLabel, (includeChildNodes == null || includeChildNodes));
+
+        String labels = searchOptions.getOptionalParameter("edgeLabels", String.class);
+
+        if (labels == null) {
+            // Try legacy edgeLabel parameter
+            String edgeLabel = searchOptions.getOptionalParameter("edgeLabel", String.class);
+            if (edgeLabel != null) {
+                final Boolean includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", Boolean.class);
+                ontologyRepository.addEdgeLabelFilterToQuery(query, edgeLabel, (includeChildNodes == null || includeChildNodes));
+            }
+        } else {
+            JSONArray types = new JSONArray(labels);
+            if (types.length() > 0) {
+                String[] iris = new String[types.length()];
+                boolean[] includes = new boolean[types.length()];
+
+                for (int i = 0; i < types.length(); i++) {
+                    JSONObject type = (JSONObject) types.get(i);
+                    iris[i] = type.getString("iri");
+                    includes[i] = type.optBoolean("includeChildNodes", false);
+                }
+                ontologyRepository.addEdgeLabelFilterToQuery(query, iris, includes);
+            }
         }
     }
 

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -267,14 +267,12 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
     }
 
     private Collection<OntologyRepository.ElementTypeFilter> getTypeFilters(String typesStr) {
-        List<OntologyRepository.ElementTypeFilter> filters = new ArrayList<>(typesStr.length());
         JSONArray types = new JSONArray(typesStr);
-        if (types.length() > 0) {
-            for (int i = 0; i < types.length(); i++) {
-                JSONObject type = (JSONObject) types.get(i);
-                OntologyRepository.ElementTypeFilter filter = ClientApiConverter.toClientApi(type, OntologyRepository.ElementTypeFilter.class);
-                filters.add(filter);
-            }
+        List<OntologyRepository.ElementTypeFilter> filters = new ArrayList<>(types.length());
+        for (int i = 0; i < types.length(); i++) {
+            JSONObject type = (JSONObject) types.get(i);
+            OntologyRepository.ElementTypeFilter filter = ClientApiConverter.toClientApi(type, OntologyRepository.ElementTypeFilter.class);
+            filters.add(filter);
         }
         return filters;
     }

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -230,18 +230,7 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
                 ontologyRepository.addConceptTypeFilterToQuery(query, conceptType, (includeChildNodes == null || includeChildNodes));
             }
         } else {
-            JSONArray types = new JSONArray(conceptTypes);
-            if (types.length() > 0) {
-                String[] iris = new String[types.length()];
-                boolean[] includes = new boolean[types.length()];
-
-                for (int i = 0; i < types.length(); i++) {
-                    JSONObject type = (JSONObject) types.get(i);
-                    iris[i] = type.getString("iri");
-                    includes[i] = type.optBoolean("includeChildNodes", false);
-                }
-                ontologyRepository.addConceptTypeFilterToQuery(query, iris, includes);
-            }
+            ontologyRepository.addConceptTypeFilterToQuery(query, getTypeFilters(conceptTypes));
         }
     }
 
@@ -258,18 +247,7 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
                 ontologyRepository.addEdgeLabelFilterToQuery(query, edgeLabel, (includeChildNodes == null || includeChildNodes));
             }
         } else {
-            JSONArray types = new JSONArray(labels);
-            if (types.length() > 0) {
-                String[] iris = new String[types.length()];
-                boolean[] includes = new boolean[types.length()];
-
-                for (int i = 0; i < types.length(); i++) {
-                    JSONObject type = (JSONObject) types.get(i);
-                    iris[i] = type.getString("iri");
-                    includes[i] = type.optBoolean("includeChildNodes", false);
-                }
-                ontologyRepository.addEdgeLabelFilterToQuery(query, iris, includes);
-            }
+            ontologyRepository.addEdgeLabelFilterToQuery(query, getTypeFilters(labels));
         }
     }
 
@@ -286,6 +264,19 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
         JSONArray filterJson = searchOptions.getRequiredParameter("filter", JSONArray.class);
         ontologyRepository.resolvePropertyIds(filterJson);
         return filterJson;
+    }
+
+    private Collection<OntologyRepository.ElementTypeFilter> getTypeFilters(String typesStr) {
+        List<OntologyRepository.ElementTypeFilter> filters = new ArrayList<>(typesStr.length());
+        JSONArray types = new JSONArray(typesStr);
+        if (types.length() > 0) {
+            for (int i = 0; i < types.length(); i++) {
+                JSONObject type = (JSONObject) types.get(i);
+                OntologyRepository.ElementTypeFilter filter = ClientApiConverter.toClientApi(type, OntologyRepository.ElementTypeFilter.class);
+                filters.add(filter);
+            }
+        }
+        return filters;
     }
 
     private void updateQueryWithFilter(Query graphQuery, JSONObject obj, User user) {

--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -596,12 +596,15 @@ search.types.visallo.hits.many={0} results
 search.types.workspace=@{alias.case}
 search.types.workspace.message=Selecting {0} of {1}
 
+search.sort.placeholder=Add Sort…
+
 search.filters.related_to=Related To
 search.filters.title_multiple={0} entities
-search.filters.all_concepts=All Concepts
-search.filters.add_filter.placeholder=Add Filter
+search.filters.all_concepts=Add Concept…
+search.filters.all_concepts.focus=Type to filter concepts…
+search.filters.add_filter.placeholder=Add Filter…
 search.filters.edgeType=Filter by Type
-search.filters.all_edgetypes=All Relationship Types
+search.filters.all_edgetypes=Add Type…
 search.filters.match.vertex=Entity
 search.filters.match.edge=Relation
 search.filters.include.child.nodes=Include descendants

--- a/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
@@ -25,11 +25,19 @@ define([
                 originalUrl = url;
 
             if (options.conceptFilter && matchType === 'vertex') {
-                params.conceptType = options.conceptFilter;
+                if (_.isArray(options.conceptFilter)) {
+                    params.conceptTypes = JSON.stringify(options.conceptFilter);
+                } else {
+                    params.conceptType = options.conceptFilter
+                }
             }
             if (options.edgeLabelFilter
                 && (matchType === 'edge' || (options.otherFilters && options.otherFilters.relatedToVertexIds))) {
-                params.edgeLabel = options.edgeLabelFilter;
+                if (_.isArray(options.edgeLabelFilter)) {
+                    params.edgeLabels = JSON.stringify(options.edgeLabelFilter);
+                } else {
+                    params.edgeLabel = options.edgeLabelFilter
+                }
             }
             if (options.paging) {
                 if (options.paging.offset) params.offset = options.paging.offset;
@@ -43,10 +51,6 @@ define([
 
             if (q) {
                 params.q = q;
-            }
-
-            if (!_.isUndefined(options.includeChildNodes)) {
-                params.includeChildNodes = options.includeChildNodes;
             }
 
             if (options.otherFilters) {

--- a/web/war/src/main/webapp/js/search/filters/entityItem.ejs
+++ b/web/war/src/main/webapp/js/search/filters/entityItem.ejs
@@ -1,7 +1,7 @@
 <li class="entity-filter-row" data-filter-key="relatedToVertexIds">
   <div class="current-property">
     <label><%= i18n('search.filters.related_to') %></label>
-    <button class="remove"><%= i18n('search.filters.button.remove') %></button>
+    <button class="remove-icon"><%= i18n('search.filters.button.remove') %></button>
   </div>
   <div class="configuration">
     <input readonly type="text" value="<%= title %>"></input>

--- a/web/war/src/main/webapp/js/search/filters/extensionItem.hbs
+++ b/web/war/src/main/webapp/js/search/filters/extensionItem.hbs
@@ -1,7 +1,7 @@
 <li class="extension-filter-row" data-filter-key="{{ filterKey }}">
   <div class="current-property">
     <label>{{ sectionHeader }}</label>
-    <button class="remove">{{ i18n 'search.filters.button.remove' }}</button>
+    <button class="remove-icon">{{ i18n 'search.filters.button.remove' }}</button>
   </div>
   <div class="configuration"></div>
 </li>

--- a/web/war/src/main/webapp/js/search/filters/filterItem.js
+++ b/web/war/src/main/webapp/js/search/filters/filterItem.js
@@ -29,7 +29,7 @@ define([
             fieldSelector: '.configuration',
             propertySelectionSelector: '.property-selector',
             currentPropertySelector: '.current-property',
-            removeSelector: '.header button.remove',
+            removeSelector: '.header button.remove-icon',
             predicateSelector: '.current-property .header .dropdown .dropdown-menu li a'
         });
 
@@ -198,7 +198,7 @@ define([
             this.select('propertySelectionSelector')
                 .toggle(!hasProperty);
             this.select('currentPropertySelector')
-                .find('label')
+                .find('label span')
                     .text(property.displayName)
                 .end()
                 .find('.dropdown-menu')

--- a/web/war/src/main/webapp/js/search/filters/filterItemTpl.hbs
+++ b/web/war/src/main/webapp/js/search/filters/filterItemTpl.hbs
@@ -1,15 +1,17 @@
 <div class="property-selector"></div>
 <div class="current-property" style="display:none">
   <div class="header">
-    <label>Property Display Name</label>
-    <button class="remove">{{ i18n 'search.filters.button.remove' }}</button>
-    <div class="dropdown">
-      <a class="dropdown-toggle" data-toggle="dropdown">
-        <span></span>
-        <b class="caret"></b>
-      </a>
-      <ul class="dropdown-menu"></ul>
-    </div>
+    <label>
+      <span><!-- Property Display Name --></span>
+      <div class="dropdown">
+        <a class="dropdown-toggle" data-toggle="dropdown">
+          <span></span>
+          <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu"></ul>
+      </div>
+    </label>
+    <button class="remove-icon">×</button>
   </div>
   <div class="fields">
     <div class="configuration"></div>

--- a/web/war/src/main/webapp/js/search/filters/filtersTpl.hbs
+++ b/web/war/src/main/webapp/js/search/filters/filtersTpl.hbs
@@ -14,15 +14,15 @@
   <li {{#unless showConceptFilter}}style="display:none"{{/unless}}
     class="concept-filter-header nav-header">{{ i18n 'search.filters.concept' }}</li>
   <li {{#unless showConceptFilter}}style="display:none"{{/unless}} class="concepts-dropdown"></li>
-  <li {{#unless showConceptFilter}}style="display:none"{{/unless}}>
-      <div class="child-nodes">
-      <label><input type="checkbox"
-      {{#if includeChildNodes}}checked{{/if}} value="includeChildNodes">{{ i18n 'search.filters.include.child.nodes' }}</label>
-      </div>
+  <li {{#unless showConceptFilter}}style="display:none"{{/unless}} class="concepts-list">
+      <ul class="fields ui-sortable"></ul>
   </li>
   <li {{#unless showEdgeFilter}}style="display:none"{{/unless}}
     class="edgetype-filter-header nav-header">{{ i18n 'search.filters.edgeType' }}</li>
   <li {{#unless showEdgeFilter}}style="display:none"{{/unless}} class="edgetype-dropdown"></li>
+  <li {{#unless showEdgeFilter}}style="display:none"{{/unless}} class="edgetype-list">
+      <ul class="fields ui-sortable"></ul>
+  </li>
   {{#if showSorting}}
   <li class="sort-filter-header nav-header">{{ i18n 'search.filters.sort' }}</li>
   <li class="sort-content"></li>

--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -428,7 +428,7 @@ define([
 
             $clear.hide();
             _.defer($query.focus.bind($query));
-            this.trigger(node, 'clearSearch')
+            this.trigger(node, 'clearSearch', { clearMatch: false })
         };
 
         this.onAdvancedSearchTypeClick = function(event) {

--- a/web/war/src/main/webapp/js/search/sort.js
+++ b/web/war/src/main/webapp/js/search/sort.js
@@ -96,7 +96,7 @@ define([
                     return p.searchable === false || p.sortable === false;
                 }),
                 onlySearchable: true,
-                placeholder: 'Add Sort...'
+                placeholder: i18n('search.sort.placeholder')
             });
         };
 

--- a/web/war/src/main/webapp/js/search/types/typeVisallo.js
+++ b/web/war/src/main/webapp/js/search/types/typeVisallo.js
@@ -80,8 +80,7 @@ define([
                     otherFilters: data.filters.otherFilters,
                     edgeLabelFilter: data.filters.edgeLabelFilter,
                     sort: data.filters.sortFields,
-                    matchType: data.filters.matchType,
-                    includeChildNodes: data.filters.includeChildNodes
+                    matchType: data.filters.matchType
                 };
                 self.triggerUpdatedSavedSearchQuery(options);
             })
@@ -117,7 +116,6 @@ define([
                     query,
                     self.currentFilters.propertyFilters,
                     self.currentFilters.matchType,
-                    self.currentFilters.includeChildNodes,
                     self.currentFilters.conceptFilter,
                     self.currentFilters.edgeLabelFilter,
                     self.currentFilters.otherFilters,
@@ -165,7 +163,6 @@ define([
             query,
             propertyFilters,
             matchType,
-            includeChildNodes,
             conceptFilter,
             edgeLabelFilter,
             otherFilters,
@@ -189,7 +186,6 @@ define([
                     conceptFilter: conceptFilter,
                     edgeLabelFilter: edgeLabelFilter,
                     otherFilters: otherFilters,
-                    includeChildNodes: includeChildNodes,
                     paging: paging,
                     sort: sortFields,
                     matchType: matchType
@@ -213,7 +209,6 @@ define([
                 query,
                 this.currentFilters.propertyFilters,
                 this.currentFilters.matchType,
-                this.currentFilters.includeChildNodes,
                 this.currentFilters.conceptFilter,
                 this.currentFilters.edgeLabelFilter,
                 this.currentFilters.otherFilters,

--- a/web/war/src/main/webapp/js/search/types/withSearch.js
+++ b/web/war/src/main/webapp/js/search/types/withSearch.js
@@ -68,11 +68,12 @@ define([
                     this.trigger($searchResults, 'paneResized');
                 }
             });
-            this.on('clearSearch', function() {
+            this.on('clearSearch', function(event, data) {
                 this.hideSearchResults();
+                console.log(event.target, data)
 
                 var filters = this.select('filtersSelector').find('.content')
-                this.trigger(filters, 'clearfilters');
+                this.trigger(filters, 'clearfilters', data);
             });
             this.on('searchtypeloaded', function(event, data) {
                 var filters = this.select('filtersSelector').find('.content')

--- a/web/war/src/main/webapp/js/search/types/withSearch.js
+++ b/web/war/src/main/webapp/js/search/types/withSearch.js
@@ -70,7 +70,6 @@ define([
             });
             this.on('clearSearch', function(event, data) {
                 this.hideSearchResults();
-                console.log(event.target, data)
 
                 var filters = this.select('filtersSelector').find('.content')
                 this.trigger(filters, 'clearfilters', data);

--- a/web/war/src/main/webapp/js/util/flight/componentHighlighter.js
+++ b/web/war/src/main/webapp/js/util/flight/componentHighlighter.js
@@ -37,14 +37,11 @@ define(['flight/lib/registry'], function(registry) {
     }
 
     function nameFromComponent(component) {
-        var name = component.toString(),
-            nameMatch = name.match(/^([^,]+)/)
-
-        if (nameMatch) {
-            name = $.trim(nameMatch[1]);
-        }
-
-        return name;
+        return component.toString()
+            .split(/\s*,\s*/)
+            .filter(n => !/^with/.test(n))
+            .sort()
+            .join(',')
     }
 
     function logComponent(name, closestComponent) {

--- a/web/war/src/main/webapp/js/util/ontology/conceptSelect.js
+++ b/web/war/src/main/webapp/js/util/ontology/conceptSelect.js
@@ -176,11 +176,9 @@ define([
         this.setupTypeahead = function() {
             var self = this;
 
-            Promise.resolve(ontology.concepts)
+            return Promise.resolve(ontology.concepts)
                 .then(this.transformConcepts.bind(this))
-                .done(function(concepts) {
-                    concepts.splice(0, 0, self.attr.defaultText);
-
+                .then(function(concepts) {
                     var field = self.select('fieldSelector')
                         .attr('placeholder', self.attr.defaultText),
                         selectedConcept;
@@ -253,6 +251,13 @@ define([
                         })
                     }
 
+                    self.on(self.select('fieldSelector'), 'blur focus', function(event) {
+                        $(event.target).attr('placeholder',
+                            event.type === 'focus' ?
+                                i18n('search.filters.all_concepts.focus') :
+                                self.attr.defaultText
+                        );
+                    })
                     self.allowEmptyLookup(field);
                 });
         }

--- a/web/war/src/main/webapp/js/util/ontology/propertySelect.js
+++ b/web/war/src/main/webapp/js/util/ontology/propertySelect.js
@@ -84,6 +84,7 @@ define([
                     .on('focus', function(e) {
                         var target = $(e.target);
                         target.attr('placeholder', PLACEHOLDER)
+                        self.focused = true;
                     })
                     .on('click', function(e) {
                         var target = $(e.target);
@@ -104,6 +105,9 @@ define([
                             target.val('');
                         }
                         target.attr('placeholder', self.attr.placeholder);
+                        if (e.type === 'blur') {
+                            self.focused = false;
+                        }
                     })
                     .typeahead({
                         minLength: 0,
@@ -286,10 +290,14 @@ define([
                 .value();
 
             var hasProperties = this.filterSourceProperties(this.propertiesForSource).length > 0;
-            var placeholderMessage = hasProperties ? 'field.selection.placeholder' : 'field.selection.no_valid';
+            var placeholderMessage = this.focused && hasProperties ?
+                i18n('field.selection.placeholder') :
+                hasProperties ?
+                this.attr.placeholder :
+                i18n('field.selection.no_valid');
 
             this.select('findPropertySelection')
-                .attr('placeholder', i18n(placeholderMessage))
+                .attr('placeholder', placeholderMessage)
                 .attr('disabled', !hasProperties);
         };
 

--- a/web/war/src/main/webapp/less/search/search.less
+++ b/web/war/src/main/webapp/less/search/search.less
@@ -229,7 +229,7 @@ width: 215px;
     overflow: auto;
     overflow-x: hidden;
   }
-  
+
   .concepts-dropdown select {
     width: 100%;
     font-size: 90%;
@@ -316,6 +316,52 @@ width: 215px;
     li { margin-bottom: 0; }
   }
 
+    
+  .edgetype-list,
+  .concepts-list {
+    .fields {
+      list-style: none;
+      margin: 0 0 0.5em 0;
+
+      li {
+        display: flex;
+        &:hover {
+          background-color: #ececec;
+          border-radius: 3px;
+        }
+        .content {
+          flex: 1 1 auto;
+          color: #777;
+          flex-wrap: wrap;
+          display: flex;
+          min-width: 0;
+          margin-left: 0.5em;
+        }
+        button { flex: 0 0 auto; }
+        .display {
+          font-size: 95%;
+          flex: 1 0 auto;
+        }
+
+        .descendants {
+          font-size: 85%;
+          color: #7b7b7b;
+          text-shadow: 0 1px 0 white;
+          white-space: nowrap;
+          margin: 0 0.3em;
+          padding: 0 0.25em;
+          input {
+            margin-right: 0.3em;
+            vertical-align: top;
+          }
+        }
+      }
+    }
+  }
+
+  .concept-selection,
+  .relationship-selection,
+  .property-select,
   .property-selector {
     input {
       @color: #0088cc;
@@ -324,7 +370,7 @@ width: 215px;
       .box-shadow(none);
       outline: none;
       border: 0;
-      background: inherit;
+      background: @pane-background;
       color: @color;
       font-size: 11px;
       font-weight: bold;
@@ -334,13 +380,28 @@ width: 215px;
       padding-left: 0;
       margin: 0;
       cursor: pointer;
+      font-style: italic;
       &::-webkit-input-placeholder { color: @color; }
       &::-moz-placeholder { color: @color; }
       &:-moz-placeholder { color: @color; }
+      &:disabled {
+        cursor: default;
+        @color: #bbb;
+        color: @color;
+        &::-webkit-input-placeholder { color: @color; }
+        &::-moz-placeholder { color: @color; }
+        &:-moz-placeholder { color: @color; }
+      }
     }
   }
   
   .entity-filter-row, .extension-filter-row {
+    .current-property {
+      display: flex;
+      & > label { flex: 1 1 auto; }
+      & > button { flex: 0 0 auto; }
+      button { margin-top: 13px; }
+    }
     .current-property label {
       font-size: 11px;
       font-weight: bold;
@@ -349,10 +410,10 @@ width: 215px;
       color: #999999;
       float: left;
       display: inline;
-      padding: 1.2ex 0.5em 0 0;
-      margin: 0;
+      padding: 0em 0.5em 0 0;
+      margin: 1.5em 0 0 0;
       cursor: default;
-      line-height: 1.5em;
+      line-height: 1em;
     }
   }
 
@@ -377,33 +438,35 @@ width: 215px;
     .clearfix;
 
     .header {
-      position: relative;
-      .clearfix;
+      display: flex;
+
+      & > label { flex: 1 1 auto;  }
+      & > .remove-icon { flex: 0 0 auto;  }
+      & > .dropdown { flex: 0 0 auto;  }
+
+      label {
+        cursor: default;
+        font-size: 95%;
+        color: #777;
+        position: relative;
+        flex: 1 1 auto;
+        display: flex;
+        flex-wrap: wrap;
+        margin-left: 0.5em;
+        & > span {
+          flex: 1 0 auto;
+          margin-right: 0.5em;
+        }
+        .dropdown {
+          position: static;
+          display: inline;
+          margin-right: 0.25em;
+        }
+        .caret { margin-top: 9px; }
+      }
     }
   }
 
-  .current-property .header label {
-    cursor: default;
-  }
-
-  .current-property .header label,
-  .current-property .header button.remove,
-  .current-property .header .dropdown {
-    line-height: 1em;
-    display: inline;
-    margin-bottom: 0.5em;
-  }
-
-  .current-property .header label,
-  .current-property .header .dropdown {
-    float: left;    
-  }
-  .current-property .header label {
-    margin-right: 0.5em;
-  }
-  .current-property .header .dropdown {
-    position: static;
-  }
   .current-property .header .dropdown .dropdown-menu {
     left: 0;
     right: 0;
@@ -531,6 +594,14 @@ width: 215px;
  
   & > li { margin-bottom: 0.5em; position: relative; }
   li.nav-header { margin-bottom: 0; margin-top: 0; }
+
+  li.concept-filter-header,
+  li.edgetype-filter-header,
+  li.sort-filter-header,
+  li.prop-filter-header {
+    margin-top: 2em;
+    line-height: 0.7em;
+  }
 
   .property-filters {
     .appearance(none);

--- a/web/war/src/main/webapp/less/util/css3.less
+++ b/web/war/src/main/webapp/less/util/css3.less
@@ -4,4 +4,5 @@
   -moz-appearance: @type;
   -ms-appearance: @type;
   -o-appearance: @type;
+  appearance: @type;
 }


### PR DESCRIPTION


- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

* Supports searching multiple concepts and edgeLabels (ORed together)
* Unified style between search sections (related, concept, sort, filter)
* Supports the previous search format so no migration necessary to make old searches load in new search tool, or execute them.

Testing Instructions: Test searching for entities using multiple concepts. Similar for edges. The results should be one of the selected concept/edgeLabels.

Points of Regression: None

CHANGELOG
Added: Multiple concepts and edge labels can be added to entity/relation search for an `IN` search

<img src="https://dl.dropboxusercontent.com/u/7953598/tempShare/search.png"/>
