### PR TITLE
Firefox: Fix table shift selection highlighting other text(3.1)

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/less/table.less
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/less/table.less
@@ -122,6 +122,10 @@
 
   .table {
     flex: 1 1 auto;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
 
       .FlexTable {
         overflow-x: auto;
@@ -136,11 +140,6 @@
               display: flex;
 
               .FlexTable__headerTruncatedText {
-                -moz-user-select: none;
-                -ms-user-select: none;
-                -webkit-user-select: none;
-                user-select: none;
-
                 &:after {
                   content: ' ';
                   display: inline-block;


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Points of Regression: other click actions in the table

CHANGELOG
Fixed: In Firefox, when shift selecting rows in the saved search table, other text on the screen would be highlighted. 
