### PR TITLE
Fix d3 error when data is empty in timeline (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/fields/histogram/histogram.js
+++ b/web/war/src/main/webapp/js/fields/histogram/histogram.js
@@ -318,11 +318,11 @@ define([
                 data = this.data = this.binValues(),
 
                 yScale = this.yScale = d3.scale.linear()
-                    .domain([0, d3.max(data, function(layer) {
+                    .domain([0, data.length ? d3.max(data, function(layer) {
                         return d3.max(layer.values, function(d) {
                             return d.y0 + d.y;
                         });
-                    })])
+                    }) : 0])
                     .range([height, 0]),
 
                 xAxis = this.xAxis = d3.svg.axis()


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Open JS console, open work product with no date properties, toggle timeline. Should be no JS errors

CHANGELOG
Fixed: Empty timeline doesn't throw JavaScript exceptions