### PR TITLE
Fix element inspector search by edge properties (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -207,7 +207,7 @@ define([
                 if (advancedSearch) {
                     self.currentSearchNode.trigger('savedQuerySelected', { query: data });
                 } else {
-                    var node = self.getSearchTypeNode().find('.search-filters .content');
+                    var node = self.getSearchTypeNode().find('.search-filters > .content');
                     if ('q' in data.parameters) {
                         self.select('querySelector').filter(':visible')
                             .val(data.parameters.q)
@@ -464,6 +464,7 @@ define([
             this.filters = data;
 
             var query = this.getQueryVal(),
+                options = (data && data.options) || {},
                 hasFilters = this.hasFilters();
 
             this.dataRequest('config', 'properties')
@@ -479,14 +480,14 @@ define([
                     }
 
                     const hasQuery = query && query.length;
-                    const validSearch = hasQuery && (hasFilters || hadFilters);
+                    const validSearch = hasQuery && (hasFilters || hadFilters || options.matchChanged);
 
-                    if (data.options && data.options.isScrubbing) {
+                    if (options.isScrubbing) {
                         self.triggerQueryUpdatedThrottled();
                     } else {
                         self.triggerQueryUpdated();
                     }
-                    if (validSearch || (data.options && data.options.submit)) {
+                    if (validSearch || options.submit) {
                         self.triggerQuerySubmit();
                     }
 


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Was throwing js error because filters component wasn't finished loading. Refactor the loading so clearfilters waits for filters to fully initialize.

Testing Instructions: Load visallo without opening search, open work product with an edge that has a searchable property. Click the "i" in element inspector and search. The relation search should run with the property filter.

Case 2: open search, clear all filters. Toggle match type shouldn't run search. Now type a search query and toggle match type => should run search 

Points of Regression:

CHANGELOG
Changed: Re-run the search if match-type (entity/relation) changes when there are no filters, but there is a search query.
Fixed: Fix issue where loading the same relation saved search with a property filter would show duplicate filters.
