### PR TITLE
fix pushing hidden and deleted properties to the queue (3.1)

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerTestBase.java
@@ -205,8 +205,8 @@ public abstract class GraphPropertyWorkerTestBase {
         return run(gpw, workerPrepareData, e, prop, in, null, null, null);
     }
 
-    protected boolean run(GraphPropertyWorker gpw, GraphPropertyWorkerPrepareData workerPrepareData, Element e, Property prop, InputStream in, ElementOrPropertyStatus status) {
-        return run(gpw, workerPrepareData, e, prop, in, null, status, null);
+    protected boolean run(GraphPropertyWorker gpw, GraphPropertyWorkerPrepareData workerPrepareData, Element e, Property prop, InputStream in, String workspaceId, ElementOrPropertyStatus status) {
+        return run(gpw, workerPrepareData, e, prop, in, workspaceId, status, null);
     }
 
     protected boolean run(
@@ -231,7 +231,9 @@ public abstract class GraphPropertyWorkerTestBase {
         }
 
         try {
-            if (!gpw.isHandled(e, prop)) {
+            if (!(status == ElementOrPropertyStatus.HIDDEN && gpw.isHiddenHandled(e, prop))
+                    && !(status == ElementOrPropertyStatus.DELETION && gpw.isDeleteHandled(e, prop))
+                    && !gpw.isHandled(e, prop)) {
                 return false;
             }
         } catch (Exception ex) {

--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -258,6 +258,10 @@ public class GraphRepositoryTest {
         assertEquals(SECRET_VISALLO_VIZ, property.getVisibility());
         assertTrue(hiddenVisibilities.hasNext());
         assertEquals(WORKSPACE_VIZ, hiddenVisibilities.next());
+
+        List<byte[]> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");
+        assertEquals(1, queue.size());
+        InMemoryWorkQueueRepository.clearQueue();
     }
 
     @Test

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkData.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkData.java
@@ -120,7 +120,15 @@ public class GraphPropertyWorkData {
         return visibilityJson;
     }
 
+    /**
+     * @deprecated  replaced by {@link #getElementVisibilityJson()}
+     */
+    @Deprecated
     public VisibilityJson getVisibilityJson() {
+        return getElementVisibilityJson();
+    }
+
+    public VisibilityJson getElementVisibilityJson() {
         VisibilityJson visibilityJson = VisalloProperties.VISIBILITY_JSON.getPropertyValue(getElement());
         if (visibilityJson != null) {
             return visibilityJson;
@@ -129,11 +137,22 @@ public class GraphPropertyWorkData {
         return getVisibilitySourceJson();
     }
 
+    public VisibilityJson getPropertyVisibilityJson() {
+        if (property != null) {
+            VisibilityJson propertyVisibilityJson = VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property);
+            if (propertyVisibilityJson != null) {
+                return propertyVisibilityJson;
+            }
+        }
+        return getElementVisibilityJson();
+    }
+
     public Metadata createPropertyMetadata(User user) {
         Metadata metadata = new Metadata();
-        VisibilityJson visibilityJson = getVisibilityJson();
+        VisibilityJson visibilityJson = getElementVisibilityJson();
         Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
         if (visibilityJson != null) {
+            
             VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, defaultVisibility);
         }
         VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(metadata, new Date(), defaultVisibility);
@@ -142,7 +161,7 @@ public class GraphPropertyWorkData {
     }
 
     public void setVisibilityJsonOnElement(ElementBuilder builder) {
-        VisibilityJson visibilityJson = getVisibilityJson();
+        VisibilityJson visibilityJson = getElementVisibilityJson();
         if (visibilityJson != null) {
             VisalloProperties.VISIBILITY_JSON.setProperty(builder, visibilityJson, visibilityTranslator.getDefaultVisibility());
         }

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/RegexGraphPropertyWorker.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/RegexGraphPropertyWorker.java
@@ -58,7 +58,7 @@ public abstract class RegexGraphPropertyWorker extends GraphPropertyWorker {
                     .end(end)
                     .title(patternGroup)
                     .conceptIri(getConcept().getIRI())
-                    .visibilityJson(data.getVisibilityJson())
+                    .visibilityJson(data.getElementVisibilityJson())
                     .process(getClass().getName())
                     .save(getGraph(), getVisibilityTranslator(), getUser(), getAuthorizations());
             termMentions.add(termMention);

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
@@ -141,6 +141,18 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
         }
     }
 
+    public void hideProperty(
+            List<VisalloPropertyUpdate> changedPropertiesOut,
+            Element element,
+            Property propertyToHide,
+            String workspaceId,
+            Authorizations authorizations
+    ) {
+        long beforeDeletionTimestamp = System.currentTimeMillis() - 1;
+        element.markPropertyHidden(propertyToHide, new Visibility(workspaceId), authorizations);
+        changedPropertiesOut.add(new VisalloPropertyUpdateRemove(this, propertyToHide.getKey(), beforeDeletionTimestamp, false, true));
+    }
+
     /**
      * @param changedPropertiesOut Adds the property to this list if the property value changed
      * @deprecated Use {@link #updateProperty(List, Element, ElementMutation, String, Object, PropertyMetadata)}

--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceHelper.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceHelper.java
@@ -141,7 +141,7 @@ public class WorkspaceHelper {
 
         graph.flush();
 
-        workQueueRepository.pushGraphPropertyQueue(e, property, status, beforeActionTimestamp, priority);
+        workQueueRepository.pushGraphPropertyQueueHiddenOrDeleted(e, property, status, beforeActionTimestamp, workspaceId, priority);
     }
 
     public void deleteEdge(

--- a/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceSandboxingTest.java
+++ b/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceSandboxingTest.java
@@ -583,11 +583,12 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
                 Priority.HIGH,
                 workspaceAuthorizations
         );
-        verify(workQueueRepository).pushGraphPropertyQueue(
+        verify(workQueueRepository).pushGraphPropertyQueueHiddenOrDeleted(
                 eq(entity1Vertex),
                 eq(property),
                 eq(ElementOrPropertyStatus.HIDDEN),
                 any(Long.class),
+                eq(WORKSPACE_ID),
                 eq(Priority.HIGH)
         );
     }


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: None, covered by another PR

Points of Regression: None

CHANGELOG
Added: Pushing onto the gpw queue when a published property has been changed
Fixed: Added an additional validation of the status when the graph property runner checks for whether or not any GPWs are interested
