### PR TITLE
Update getting started guide to run compile before server

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,10 @@ Change directories to the checked out code. This is your `$PROJECT_DIR` director
 
       cd visallo
 
+Compile the application (optionally run tests.)
+      
+      mvn -DskipTests compile      
+
 Run the web application.
 
       mvn -am -pl dev/tomcat-server -P dev-tomcat-run compile


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

I've noticed that the run server command doesn't collect all the dependencies (notably webapp module) so the app won't be built without first running `mvn compile`
