### PR TITLE
Fixed: Tomcat exceptions in Atmosphere when session expires

### DIFF
--- a/web/server/server-base/src/main/java/org/visallo/web/WebServer.java
+++ b/web/server/server-base/src/main/java/org/visallo/web/WebServer.java
@@ -10,7 +10,6 @@ public abstract class WebServer extends CommandLineTool {
     public static final int DEFAULT_SERVER_PORT = 8080;
     public static final int DEFAULT_HTTPS_SERVER_PORT = 8443;
     public static final String DEFAULT_CONTEXT_PATH = "";
-    public static final int DEFAULT_SESSION_TIMEOUT = 30;
     public static final String DEFAULT_KEYSTORE_TYPE = "JKS";
 
     @Parameter(names = {"--port"}, arity = 1, description = "The port to run the HTTP connector on")
@@ -48,9 +47,6 @@ public abstract class WebServer extends CommandLineTool {
 
     @Parameter(names = {"--contextPath"}, arity = 1, description = "Context path for the webapp")
     private String contextPath = DEFAULT_CONTEXT_PATH;
-
-    @Parameter(names = {"--sessionTimeout"}, arity = 1, description = "number of minutes before idle sessions expire")
-    private int sessionTimeout = DEFAULT_SESSION_TIMEOUT;
 
     public int getHttpPort() {
         return httpPort;
@@ -98,9 +94,5 @@ public abstract class WebServer extends CommandLineTool {
 
     public File getWebAppDir() {
         return webAppDir;
-    }
-
-    public int getSessionTimeout() {
-        return sessionTimeout;
     }
 }

--- a/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
+++ b/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
@@ -48,7 +48,6 @@ public class TomcatWebServer extends WebServer {
         defaultConnector.setRedirectPort(super.getHttpsPort());
 
         Context context = tomcat.addWebapp(this.getContextPath(), getWebAppDir().getAbsolutePath());
-        context.setSessionTimeout(super.getSessionTimeout());
 
         // don't scan classpath for web components to avoid benign log warnings
         StandardJarScanner jarScanner = new StandardJarScanner();

--- a/web/war/src/main/webapp/WEB-INF/web.xml
+++ b/web/war/src/main/webapp/WEB-INF/web.xml
@@ -6,4 +6,10 @@
         <listener-class>org.visallo.web.ApplicationBootstrap</listener-class>
     </listener>
     <distributable/>
+
+    <!--
+    <session-config>
+        <session-timeout>1</session-timeout>
+    </session-config>
+    -->
 </web-app>

--- a/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
+++ b/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
@@ -2,10 +2,7 @@ package org.visallo.web;
 
 import com.google.inject.Injector;
 import org.atmosphere.cache.UUIDBroadcasterCache;
-import org.atmosphere.cpr.AtmosphereHandler;
-import org.atmosphere.cpr.AtmosphereInterceptor;
-import org.atmosphere.cpr.AtmosphereServlet;
-import org.atmosphere.cpr.SessionSupport;
+import org.atmosphere.cpr.*;
 import org.atmosphere.interceptor.HeartbeatInterceptor;
 import org.visallo.core.bootstrap.InjectHelper;
 import org.visallo.core.bootstrap.VisalloBootstrap;
@@ -160,16 +157,17 @@ public class ApplicationBootstrap implements ServletContextListener {
         servlet.setAsyncSupported(true);
         servlet.setLoadOnStartup(0);
         servlet.setInitParameter(AtmosphereHandler.class.getName(), Messaging.class.getName());
-        servlet.setInitParameter("org.atmosphere.cpr.sessionSupport", "true");
-        servlet.setInitParameter("org.atmosphere.cpr.broadcastFilterClasses", MessagingFilter.class.getName() + "," +
+        servlet.setInitParameter(ApplicationConfig.PROPERTY_SESSION_CREATE, "false");
+        servlet.setInitParameter(ApplicationConfig.PROPERTY_SESSION_SUPPORT, "true");
+        servlet.setInitParameter(ApplicationConfig.BROADCAST_FILTER_CLASSES, MessagingFilter.class.getName() + "," +
                 MessagingThrottleFilter.class.getName());
         servlet.setInitParameter(AtmosphereInterceptor.class.getName(), HeartbeatInterceptor.class.getName());
-        servlet.setInitParameter("org.atmosphere.interceptor.HeartbeatInterceptor.heartbeatFrequencyInSeconds", "30");
-        servlet.setInitParameter("org.atmosphere.cpr.CometSupport.maxInactiveActivity", "-1");
-        servlet.setInitParameter("org.atmosphere.cpr.broadcasterCacheClass", UUIDBroadcasterCache.class.getName());
-        servlet.setInitParameter("org.atmosphere.cpr.dropAccessControlAllowOriginHeader", "true");
-        servlet.setInitParameter("org.atmosphere.websocket.maxTextMessageSize", "1048576");
-        servlet.setInitParameter("org.atmosphere.websocket.maxBinaryMessageSize", "1048576");
+        servlet.setInitParameter(ApplicationConfig.HEARTBEAT_INTERVAL_IN_SECONDS, "30");
+        servlet.setInitParameter(ApplicationConfig.MAX_INACTIVE, "-1");
+        servlet.setInitParameter(ApplicationConfig.BROADCASTER_CACHE, UUIDBroadcasterCache.class.getName());
+        servlet.setInitParameter(ApplicationConfig.DROP_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "true");
+        servlet.setInitParameter(ApplicationConfig.WEBSOCKET_MAXTEXTSIZE, "1048576");
+        servlet.setInitParameter(ApplicationConfig.WEBSOCKET_MAXBINARYSIZE, "1048576");
 
         addSecurityConstraint(servlet, config);
     }


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Tomcat deletes the session before Atmosphere's disconnect gets called
causing the user's id to not be found resulting in an exception thrown.
The user's session count is depricated by web/web-base/src/main/java/org/visallo/web/SessionUser.java
valueUnbound

Testing:
Login as a user and let the session expire. This should not throw an exception and exceptions should not show up in the log.

CHANGELOG
Fixed: Tomcat exceptions in Atmosphere when session expires
