### PR TITLE
Added: configuration to set web session expiration

### DIFF
--- a/web/war/src/main/webapp/WEB-INF/web.xml
+++ b/web/war/src/main/webapp/WEB-INF/web.xml
@@ -6,10 +6,7 @@
         <listener-class>org.visallo.web.ApplicationBootstrap</listener-class>
     </listener>
     <distributable/>
-
-    <!--
-    <session-config>
-        <session-timeout>1</session-timeout>
-    </session-config>
-    -->
+    <listener>
+        <listener-class>org.visallo.web.VisalloSessionListener</listener-class>
+    </listener>
 </web-app>

--- a/web/web-base/src/main/java/org/visallo/web/VisalloSessionListener.java
+++ b/web/web-base/src/main/java/org/visallo/web/VisalloSessionListener.java
@@ -1,0 +1,47 @@
+package org.visallo.web;
+
+import org.visallo.core.bootstrap.InjectHelper;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+public class VisalloSessionListener implements HttpSessionListener {
+    private Integer maxSessionInactiveIntervalSeconds;
+    private Configuration configuration;
+
+    @Override
+    public void sessionCreated(HttpSessionEvent event) {
+        HttpSession session = event.getSession();
+        if (session != null) {
+            session.setMaxInactiveInterval(getMaxSessionInactiveIntervalSeconds());
+        }
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent event) {
+
+    }
+
+    public int getMaxSessionInactiveIntervalSeconds() {
+        if (maxSessionInactiveIntervalSeconds == null) {
+            maxSessionInactiveIntervalSeconds = getConfiguration().getInt(
+                    WebConfiguration.MAX_SESSION_INACTIVE_INTERVAL_SECONDS
+            );
+            // Logger needs to be late bound because this class is created very early in the lifecycle
+            VisalloLogger logger = VisalloLoggerFactory.getLogger(VisalloSessionListener.class);
+            logger.info("Session timeout set to %d seconds", maxSessionInactiveIntervalSeconds);
+        }
+        return maxSessionInactiveIntervalSeconds;
+    }
+
+    public Configuration getConfiguration() {
+        if (configuration == null) {
+            configuration = InjectHelper.getInstance(Configuration.class);
+        }
+        return configuration;
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
@@ -39,21 +39,32 @@ public class WebConfiguration {
     public static final String LOGIN_SHOW_POWERED_BY = PREFIX + "login.showPoweredBy";
     public static final String SHOW_VERSION_COMMENTS = PREFIX + "showVersionComments";
     public static final String SHOW_VISIBILITY_IN_DETAILS_PANE = PREFIX + "showVisibilityInDetailsPane";
-    public static final PropertyMetadata PROPERTY_METADATA_SOURCE_TIMEZONE = new PropertyMetadata("http://visallo.org#sourceTimezone",
+    public static final String MAX_SESSION_INACTIVE_INTERVAL_SECONDS = PREFIX + "maxSessionInactiveIntervalSeconds";
+    public static final PropertyMetadata PROPERTY_METADATA_SOURCE_TIMEZONE = new PropertyMetadata(
+            "http://visallo.org#sourceTimezone",
             "properties.metadata.label.source_timezone",
-            "timezone");
-    public static final PropertyMetadata PROPERTY_METADATA_MODIFIED_DATE = new PropertyMetadata(VisalloProperties.MODIFIED_DATE,
+            "timezone"
+    );
+    public static final PropertyMetadata PROPERTY_METADATA_MODIFIED_DATE = new PropertyMetadata(
+            VisalloProperties.MODIFIED_DATE,
             "properties.metadata.label.modified_date",
-            "datetime");
-    public static final PropertyMetadata PROPERTY_METADATA_MODIFIED_BY = new PropertyMetadata(VisalloProperties.MODIFIED_BY,
+            "datetime"
+    );
+    public static final PropertyMetadata PROPERTY_METADATA_MODIFIED_BY = new PropertyMetadata(
+            VisalloProperties.MODIFIED_BY,
             "properties.metadata.label.modified_by",
-            "user");
-    public static final PropertyMetadata PROPERTY_METADATA_STATUS = new PropertyMetadata("sandboxStatus",
+            "user"
+    );
+    public static final PropertyMetadata PROPERTY_METADATA_STATUS = new PropertyMetadata(
+            "sandboxStatus",
             "properties.metadata.label.status",
-            "sandboxStatus");
-    public static final PropertyMetadata PROPERTY_METADATA_CONFIDENCE = new PropertyMetadata(VisalloProperties.CONFIDENCE_METADATA,
+            "sandboxStatus"
+    );
+    public static final PropertyMetadata PROPERTY_METADATA_CONFIDENCE = new PropertyMetadata(
+            VisalloProperties.CONFIDENCE_METADATA,
             "properties.metadata.label.confidence",
-            "percent");
+            "percent"
+    );
 
     public static final Map<String, String> DEFAULTS = new HashMap<>();
 
@@ -124,6 +135,7 @@ public class WebConfiguration {
 
         DEFAULTS.put(MAP_PROVIDER, MapProvider.OSM.toString());
         DEFAULTS.put(MAP_PROVIDER_OSM_URL, "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        DEFAULTS.put(MAX_SESSION_INACTIVE_INTERVAL_SECONDS, Integer.toString(30 * 60));
     }
 
     public static class PropertyMetadata {


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Java web containers typically require the configuration of web session
expiration using the web.xml file. Since Visallo ships a pre-built war
file this commit allows software to configure the web session timeout
without repackaging the war file.

CHANGELOG
Added: configuration to set web session expiration