### PR TITLE
Added: support to remove extended data properties

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/workspace/MockWorkProduct.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workspace/MockWorkProduct.java
@@ -1,0 +1,37 @@
+package org.visallo.core.model.workspace;
+
+import org.json.JSONObject;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.Vertex;
+import org.vertexium.Visibility;
+import org.visallo.core.model.graph.GraphUpdateContext;
+import org.visallo.core.model.workspace.product.WorkProduct;
+import org.visallo.core.user.User;
+
+public class MockWorkProduct implements WorkProduct {
+    @Override
+    public void update(
+            GraphUpdateContext ctx,
+            Vertex workspaceVertex,
+            Vertex productVertex,
+            JSONObject params,
+            User user,
+            Visibility visibility,
+            Authorizations authorizations
+    ) {
+
+    }
+
+    @Override
+    public JSONObject getExtendedData(
+            Graph graph,
+            Vertex workspaceVertex,
+            Vertex productVertex,
+            JSONObject params,
+            User user,
+            Authorizations authorizations
+    ) {
+        return new JSONObject();
+    }
+}

--- a/core/core-test/src/main/java/org/visallo/core/model/workspace/WorkspaceRepositoryTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workspace/WorkspaceRepositoryTestBase.java
@@ -1,0 +1,65 @@
+package org.visallo.core.model.workspace;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.visallo.core.model.workspace.product.Product;
+import org.visallo.core.user.User;
+import org.visallo.core.util.VisalloInMemoryTestBase;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public abstract class WorkspaceRepositoryTestBase extends VisalloInMemoryTestBase {
+    @Override
+    protected abstract WorkspaceRepository getWorkspaceRepository();
+
+    @Test
+    public void testUpdateProductExtendedData() {
+        User user = getUserRepository().getSystemUser();
+
+        Workspace workspace = getWorkspaceRepository().add("ws1", "workspace 1", user);
+        String workspaceId = workspace.getWorkspaceId();
+
+        String kind = MockWorkProduct.class.getName();
+        JSONObject params = new JSONObject();
+        JSONObject extendedData = new JSONObject();
+        extendedData.put("key1", "value1");
+        extendedData.put("key2", "value2");
+        extendedData.put("key3", new JSONObject("{\"a\":\"b\"}"));
+        params.put("extendedData", extendedData);
+        Product product = getWorkspaceRepository().addOrUpdateProduct(
+                workspaceId,
+                "p1",
+                "product 1",
+                kind,
+                params,
+                user
+        );
+        String productId = product.getId();
+
+        product = getWorkspaceRepository().findProductById(workspaceId, productId, new JSONObject(), true, user);
+        assertEquals("value1", product.getExtendedData().get("key1"));
+        assertEquals("value2", product.getExtendedData().get("key2"));
+        Object value3 = product.getExtendedData().get("key3");
+        assertTrue(value3 instanceof Map);
+        assertEquals("b", ((Map) value3).get("a"));
+
+        // update extended data
+        params = new JSONObject();
+        extendedData = new JSONObject();
+        extendedData.put("key1", JSONObject.NULL);
+        extendedData.put("key2", "value2b");
+        extendedData.put("key3", new JSONObject("{\"a\":\"b2\"}"));
+        params.put("extendedData", extendedData);
+        getWorkspaceRepository().addOrUpdateProduct(workspaceId, productId, null, null, params, user);
+
+        product = getWorkspaceRepository().findProductById(workspaceId, productId, new JSONObject(), true, user);
+        assertEquals(null, product.getExtendedData().get("key1"));
+        assertEquals("value2b", product.getExtendedData().get("key2"));
+        value3 = product.getExtendedData().get("key3");
+        assertTrue(value3 instanceof Map);
+        assertEquals("b2", ((Map) value3).get("a"));
+    }
+}

--- a/core/core-test/src/test/java/org/visallo/core/model/workspace/VertexiumWorkspaceRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/workspace/VertexiumWorkspaceRepositoryTest.java
@@ -1,0 +1,39 @@
+package org.visallo.core.model.workspace;
+
+import org.junit.Before;
+import org.visallo.core.model.workspace.product.WorkProduct;
+import org.visallo.vertexium.model.workspace.VertexiumWorkspaceRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VertexiumWorkspaceRepositoryTest extends WorkspaceRepositoryTestBase {
+    private WorkspaceRepository workspaceRepository;
+
+    @Before
+    public void before() {
+        super.before();
+        workspaceRepository = new VertexiumWorkspaceRepository(
+                getGraph(),
+                getConfiguration(),
+                getGraphRepository(),
+                getUserRepository(),
+                getGraphAuthorizationRepository(),
+                getWorkspaceDiffHelper(),
+                getLockRepository(),
+                getVisibilityTranslator(),
+                getTermMentionRepository(),
+                getOntologyRepository(),
+                getWorkQueueRepository(),
+                getAuthorizationRepository()
+        );
+        List<WorkProduct> workProducts = new ArrayList<>();
+        workProducts.add(new MockWorkProduct());
+        ((VertexiumWorkspaceRepository) workspaceRepository).setWorkProducts(workProducts);
+    }
+
+    @Override
+    protected WorkspaceRepository getWorkspaceRepository() {
+        return workspaceRepository;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
@@ -122,6 +122,14 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
         m.softDeleteProperty(key, getPropertyName(), visibility);
     }
 
+    public <T extends Element> void removeProperty(
+            ElementUpdateContext<T> ctx,
+            String propertyKey,
+            Visibility visibility
+    ) {
+        removeProperty(ctx.getMutation(), propertyKey, visibility);
+    }
+
     public void alterVisibility(ExistingElementMutation<?> elementMutation, String propertyKey, Visibility newVisibility) {
         elementMutation.alterPropertyVisibility(propertyKey, getPropertyName(), newVisibility);
     }


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

This commit allows removal of extended data properties by passing a null
for that property value. This commit also adds unit testing and argument
checking.

CHANGELOG
Added: support to remove extended data properties