### PR TITLE
Model-Vertexium: Eliminate workspace entity cache (3.1)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
@@ -854,6 +854,7 @@ public abstract class WorkspaceRepository {
         LOGGER.warn("new has image edge without a glyph icon property being set on vertex %s", entityVertex.getId());
     }
 
+    @Deprecated
     public List<String> findEntityVertexIds(Workspace workspace, User user) {
         List<WorkspaceEntity> workspaceEntities = findEntities(workspace, user);
         return toList(new ConvertingIterable<WorkspaceEntity, String>(workspaceEntities) {


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [ ] joeybrk372 rygim jharwig EvanOxfeld

Prevents VertexiumWorkspaceRepository from returning stale results. Cache was only used during retrieval of case diffs, which need to be current.

Testing Instructions: Verify actions that update the diff count badge and diff panel.

Points of Regression: None

CHANGELOG
Fixed: Always retrieve latest case diffs from the graph
