### PR TITLE
Web: Secure work product edges (3.1.1)

### DIFF
--- a/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/product/reducerTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/product/reducerTest.js
@@ -116,5 +116,99 @@ define([
                 }
             });
         });
+
+        describe('ELEMENT_UPDATE', () => {
+            it('should update extendedData with added edges', () => {
+                const nextState = reducer(
+                    genState({
+                        products: {
+                            p1: {
+                                id: 'p1',
+                                extendedData: {
+                                    edges: [],
+                                    vertices: [],
+                                    unauthorizedEdgeIds: [ 'e1' ]
+                                }
+                            }
+                        }
+                    }),
+                    {
+                        type: 'ELEMENT_UPDATE',
+                        payload: {
+                            edges: [
+                                {
+                                    id: 'e1',
+                                    inVertexId: 'v1',
+                                    label: 'l',
+                                    outVertexId: 'v2'
+                                }
+                            ],
+                            vertices: [],
+                            workspaceId
+                        }
+                    }
+                );
+                nextState.workspaces[workspaceId].products['p1'].should.deep.equal({
+                    id: 'p1',
+                    extendedData: {
+                        edges: [
+                            {
+                                edgeId: 'e1',
+                                inVertexId: 'v1',
+                                label: 'l',
+                                outVertexId: 'v2'
+                            }
+                        ],
+                        vertices: [],
+                        unauthorizedEdgeIds: []
+                    }
+                });
+            });
+
+            it('should update extendedData with deleted edges', () => {
+                const nextState = reducer(
+                    genState({
+                        products: {
+                            p1: {
+                                id: 'p1',
+                                extendedData: {
+                                    edges: [
+                                        {
+                                            edgeId: 'e1',
+                                            inVertexId: 'v1',
+                                            label: 'l',
+                                            outVertexId: 'v2'
+                                        }
+                                    ],
+                                    vertices: [],
+                                    unauthorizedEdgeIds: []
+                                }
+                            }
+                        }
+                    }),
+                    {
+                        type: 'ELEMENT_UPDATE',
+                        payload: {
+                            edges: [
+                                {
+                                    id: 'e1',
+                                    _DELETED: true
+                                }
+                            ],
+                            vertices: [],
+                            workspaceId
+                        }
+                    }
+                );
+                nextState.workspaces[workspaceId].products['p1'].should.deep.equal({
+                    id: 'p1',
+                    extendedData: {
+                        edges: [],
+                        vertices: [],
+                        unauthorizedEdgeIds: [ 'e1' ]
+                    }
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Updates ProductGet endpoint to return a lists of authorized edges and unauthorized edge IDs.

Points of Regression: Possibly edges moving between the sandbox and public or collaborating on edges with users with different authorizations.

CHANGELOG
Fixed: Brief display of some edges breaking the case sandbox when switching graphs
