### PR TITLE
Fix: Firefox list item right click not opening context menu(3.1.1)

### DIFF
--- a/web/war/src/main/webapp/js/util/element/list.js
+++ b/web/war/src/main/webapp/js/util/element/list.js
@@ -230,17 +230,17 @@ define([
             })
         };
 
-        this.onContextMenu = function(evt) {
-            evt.preventDefault();
-            evt.stopPropagation();
+        this.onContextMenu = function(e) {
+            e.preventDefault();
+            e.stopPropagation();
 
-            var vertexId = $(evt.target).closest('.element-item').children('a').data('vertexId');
+            var vertexId = $(e.target).closest('.element-item').children('a').data('vertexId');
             if (vertexId) {
                 this.trigger(this.$node, 'showVertexContextMenu', {
                     vertexId: vertexId,
                     position: {
-                        x: event.pageX,
-                        y: event.pageY
+                        x: e.pageX,
+                        y: e.pageY
                     }
                 });
             }


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

CHANGELOG
Fixed: Right clicking an item from a list in Firefox would not bring up the Context Menu.
