### PR TITLE
Fix dependent properties swapping values when editing(3.1.2)

### DIFF
--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -340,7 +340,10 @@ define([
                         const dependentProperties = property.key ?
                             F.vertex.props(self.attr.data, propertyName, property.key) :
                             F.vertex.props(self.attr.data, propertyName);
-                        self.currentValue = _.pluck(dependentProperties, 'value');
+                        self.currentValue = propertyDetails.dependentPropertyIris.map((iri) => {
+                            let property = dependentProperties.find((property) => property.name === iri);
+                            return property === undefined ? '' : property.value;
+                        });
                         fieldComponent = 'fields/compound/compound';
                     } else if (propertyDetails.displayType === 'duration') {
                         fieldComponent = 'fields/duration';


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

CHANGELOG
Fixed: When editing a compound property different field values would sometimes switch if you only modified the visibility of the property.
