### PR TITLE
Allow generated code to add visibilities (master)

### DIFF
--- a/docs/extension-points/back-end/ingestion/codegen.md
+++ b/docs/extension-points/back-end/ingestion/codegen.md
@@ -108,6 +108,7 @@ Through this pattern you can create any number of entities and relationships by 
 
 ### Visibility
 
+#### Entity 
 Adding visibility to the saved entities is possible through the Java API. In the following code example the first phone number entry, its title property, and the edges have the visibility label of "TS" added to them so that they may be tagged with that visibility when it enters the system:
 
 
@@ -128,4 +129,20 @@ Adding visibility to the saved entities is possible through the Java API. In the
     }
 ```
 
-Very similar method calls can be done in the system in the same manner as adding the visibilities.
+#### Properties
+Visibilities on entity properties can be set through the code that is generated. To set the visibility of a property, call the version of the method that applies the visibility string to the entity and it will be saved with that visibility.
+
+In the following example a phone number entity is created that contains two phone number properties. If the user that views the entity has an authorization of "A" and not "B", they will only be able to see the first property that has the visibility of "A". If they have both "A" and "B", they will be able to see both values on the entity.
+
+```java
+    @Override
+    protected int run() throws Exception {
+        PhoneNumber phoneNumber = new PhoneNumber("phonenumber1");
+        phoneNumber.addPhoneNumber("1", "(555) 555-5555", "A");
+        phoneNumber.addPhoneNumber("2", "(123) 456-7890", "B");
+
+        ingestRepository.save(phoneNumber);
+
+        return 0;
+    }
+```

--- a/tools/ontology-ingest/codegen/src/main/java/org/visallo/tools/ontology/ingest/codegen/EntityWriter.java
+++ b/tools/ontology-ingest/codegen/src/main/java/org/visallo/tools/ontology/ingest/codegen/EntityWriter.java
@@ -95,18 +95,30 @@ public abstract class EntityWriter {
             writer.println("  public static final " + visalloPropertyType + " " + constantName + " = new " + visalloPropertyType + "(\"" + property.getTitle() + "\");");
             if (propertyType.equals("Date")) {
                 writer.println(String.format(
-                        "  public %s set%s(Object value, SimpleDateFormat dateFormat) { return add%s(\"\", value, dateFormat); }",
-                        propertyAdditionType, upperCamelCasePropertyName, upperCamelCasePropertyName));
+                        "  public %s set%s(Object value, SimpleDateFormat dateFormat) { return add%2$s(\"\", value, dateFormat); }",
+                        propertyAdditionType, upperCamelCasePropertyName));
                 writer.println(String.format(
-                        "  public %s add%s(String key, Object value, SimpleDateFormat dateFormat) { return %s(%s.getPropertyName(), key, value, dateFormat); }",
+                        "  public %s set%s(Object value, SimpleDateFormat dateFormat, String visibility) { return add%2$s(\"\", value, dateFormat, visibility); }",
+                        propertyAdditionType, upperCamelCasePropertyName));
+                writer.println(String.format(
+                        "  public %s add%s(String key, Object value, SimpleDateFormat dateFormat) { return add%2$s(key, value, dateFormat, null); }",
+                        propertyAdditionType, upperCamelCasePropertyName, helperMethodName, constantName
+                ));
+                writer.println(String.format(
+                        "  public %s add%s(String key, Object value, SimpleDateFormat dateFormat, String visibility) { return %s(%s.getPropertyName(), key, value, dateFormat, visibility); }",
                         propertyAdditionType, upperCamelCasePropertyName, helperMethodName, constantName
                 ));
             } else {
                 writer.println(String.format(
-                        "  public %s set%s(Object value) { return add%s(\"\", value); }",
-                        propertyAdditionType, upperCamelCasePropertyName, upperCamelCasePropertyName));
+                        "  public %s set%s(Object value) { return add%2$s(\"\", value); }", propertyAdditionType, upperCamelCasePropertyName));
                 writer.println(String.format(
-                        "  public %s add%s(String key, Object value) { return %s(%s.getPropertyName(), key, value); }",
+                        "  public %s set%s(Object value, String visibility) { return add%2$s(\"\", value, visibility); }",
+                        propertyAdditionType, upperCamelCasePropertyName));
+                writer.println(String.format(
+                        "  public %s add%s(String key, Object value) { return add%2$s(key, value, null); }",
+                        propertyAdditionType, upperCamelCasePropertyName));
+                writer.println(String.format(
+                        "  public %s add%s(String key, Object value, String visibility) { return %s(%s.getPropertyName(), key, value, visibility); }",
                         propertyAdditionType, upperCamelCasePropertyName, helperMethodName, constantName
                 ));
             }

--- a/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/EntityBuilder.java
+++ b/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/EntityBuilder.java
@@ -1,6 +1,7 @@
 package org.visallo.tools.ontology.ingest.common;
 
 import com.google.common.base.Strings;
+import org.vertexium.Visibility;
 import org.vertexium.type.GeoPoint;
 import org.visallo.core.exception.VisalloException;
 
@@ -63,15 +64,23 @@ public abstract class EntityBuilder {
     }
 
     protected PropertyAddition<String> addStringProperty(String iri, String key, Object value) {
+        return addStringProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<String> addStringProperty(String iri, String key, Object value, String visibility) {
         String strValue = null;
         if (value != null) {
             strValue = value.toString();
             strValue = Strings.isNullOrEmpty(strValue) ? null : strValue;
         }
-        return addTo(iri, key, strValue);
+        return addTo(iri, key, strValue, visibility);
     }
 
     protected PropertyAddition<Date> addDateProperty(String iri, String key, Object value, SimpleDateFormat dateFormat) {
+        return addDateProperty(iri, key, value, dateFormat, null);
+    }
+
+    protected PropertyAddition<Date> addDateProperty(String iri, String key, Object value, SimpleDateFormat dateFormat, String visibility) {
         Date dateValue = null;
         if (value != null) {
             if (value instanceof Date) {
@@ -85,10 +94,14 @@ public abstract class EntityBuilder {
                 }
             }
         }
-        return addTo(iri, key, dateValue);
+        return addTo(iri, key, dateValue, visibility);
     }
 
     protected PropertyAddition<byte[]> addByteArrayProperty(String iri, String key, Object value) {
+        return addByteArrayProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<byte[]> addByteArrayProperty(String iri, String key, Object value, String visibility) {
         byte[] byteArrayValue = null;
         if (value != null) {
             if (value instanceof byte[]) {
@@ -97,10 +110,14 @@ public abstract class EntityBuilder {
                 throw new VisalloException("Unable to assign value " + value + " as byte[]");
             }
         }
-        return addTo(iri, key, byteArrayValue);
+        return addTo(iri, key, byteArrayValue, visibility);
     }
 
     protected PropertyAddition<Boolean> addBooleanProperty(String iri, String key, Object value) {
+        return addBooleanProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<Boolean> addBooleanProperty(String iri, String key, Object value, String visibility) {
         Boolean booleanValue = null;
         if (value != null) {
             if (value instanceof Boolean) {
@@ -109,10 +126,14 @@ public abstract class EntityBuilder {
                 booleanValue = Boolean.valueOf(value.toString().trim());
             }
         }
-        return addTo(iri, key, booleanValue);
+        return addTo(iri, key, booleanValue, visibility);
     }
 
     protected PropertyAddition<Double> addDoubleProperty(String iri, String key, Object value) {
+        return addDoubleProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<Double> addDoubleProperty(String iri, String key, Object value, String visibility) {
         Double doubleValue = null;
         if (value != null) {
             if (value instanceof String) {
@@ -126,10 +147,14 @@ public abstract class EntityBuilder {
                 doubleValue = (Double) value;
             }
         }
-        return addTo(iri, key, doubleValue);
+        return addTo(iri, key, doubleValue, visibility);
     }
 
     protected PropertyAddition<Integer> addIntegerProperty(String iri, String key, Object value) {
+        return addIntegerProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<Integer> addIntegerProperty(String iri, String key, Object value, String visibility) {
         Integer intValue = null;
         if (value != null) {
             if (value instanceof String) {
@@ -143,10 +168,14 @@ public abstract class EntityBuilder {
                 intValue = (Integer) value;
             }
         }
-        return addTo(iri, key, intValue);
+        return addTo(iri, key, intValue, visibility);
     }
 
     protected PropertyAddition<Long> addLongProperty(String iri, String key, Object value) {
+        return addLongProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<Long> addLongProperty(String iri, String key, Object value, String visibility) {
         Long longValue = null;
         if (value != null) {
             if (value instanceof String) {
@@ -162,19 +191,23 @@ public abstract class EntityBuilder {
                 longValue = (Long) value;
             }
         }
-        return addTo(iri, key, longValue);
+        return addTo(iri, key, longValue, visibility);
     }
 
     protected PropertyAddition<GeoPoint> addGeoPointProperty(String iri, String key, Object value) {
+        return addGeoPointProperty(iri, key, value, null);
+    }
+
+    protected PropertyAddition<GeoPoint> addGeoPointProperty(String iri, String key, Object value, String visibility) {
         GeoPoint geoValue = null;
         if (value != null) {
             geoValue = (GeoPoint) value;
         }
-        return addTo(iri, key, geoValue);
+        return addTo(iri, key, geoValue, visibility);
     }
 
-    private <T> PropertyAddition<T> addTo(String iri, String key, T value) {
-        PropertyAddition<T> addition = new PropertyAddition<>(iri, key, value);
+    private <T> PropertyAddition<T> addTo(String iri, String key, T value, String visibility) {
+        PropertyAddition<T> addition = new PropertyAddition<>(iri, key, value).withVisibility(visibility);
         propertyAdditions.add(addition);
         return addition;
     }


### PR DESCRIPTION
It is difficult with the current api to set different visibilities for data that is ingested. These modifications alter the api to allow entities to create properties with different visibilities.

- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions: Use the code generator to generate ontology classes

Points of Regression: None

CHANGELOG
Changed: Can set visibility to ontology generated class properties
