### PR TITLE
Add `concept` scope to formulas

### DIFF
--- a/docs/getting-started/ontology.md
+++ b/docs/getting-started/ontology.md
@@ -130,6 +130,13 @@ repository.ontology.owl.default.dir=$VISALLO_DIR/config/ontology-sample
 * **titleFormula** - A JavaScript snippet used to display the title of the entity. The snipped could be a single expression, or multiple lines with a `return`. All formulas have access to:
     * `vertex`: The json vertex object (if the element is vertex)
     * `edge`: The json edge object (if the element is an edge)
+    * `ontology`: The json ontology object (concept/relation)
+        * `id` The iri
+        * `displayName` The display name of type
+        * `parentConcept` Parent iri (if vertex and is a child type)
+        * `parentIri` Parent iri (if edge and is a child type)
+        * `pluralDisplayName` The plural display name of type
+        * `properties` The property iris defined on this type
     * `prop`: Function that accepts a property IRI and returns the display value.
     * `propRaw`: Function that accepts a property IRI and returns the raw value.
 

--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -1207,16 +1207,20 @@ define([
 
     return $.extend({}, F, { vertex: V, vertexUrl: vertexUrl.vertexUrl, edge: E });
 
-    function treeLookupForConceptProperty(conceptId, propertyName) {
+    function treeLookupForConceptProperty(conceptId, propertyName, additionalScope) {
         var ontologyConcept = conceptId && ontology.concepts.byId[conceptId],
             formulaString = ontologyConcept && ontologyConcept[propertyName];
+
+        if (ontologyConcept && !additionalScope.ontology) {
+            additionalScope.ontology = ontologyConcept
+        }
 
         if (formulaString) {
             return formulaString;
         }
 
         if (ontologyConcept && ontologyConcept.parentConcept) {
-            return treeLookupForConceptProperty(ontologyConcept.parentConcept, propertyName);
+            return treeLookupForConceptProperty(ontologyConcept.parentConcept, propertyName, additionalScope);
         }
     }
 
@@ -1232,11 +1236,12 @@ define([
                 ontologyRelation = ontology.relationships.byTitle[edge.label],
                 label = ontologyRelation.displayName;
             additionalScope.label = label;
+            additionalScope.ontology = ontologyRelation;
             formulaString = ontologyRelation[formulaKey];
         } else if (isVertex) {
             var vertex = vertexOrEdge,
                 conceptId = V.prop(vertex, 'conceptType');
-            formulaString = treeLookupForConceptProperty(conceptId, formulaKey);
+            formulaString = treeLookupForConceptProperty(conceptId, formulaKey, additionalScope);
         } else {
             if (formulaKey === 'titleFormula') {
                 return i18n('element.unauthorized').toUpperCase();

--- a/web/war/src/main/webapp/test/unit/mocks/ontologyPromise.js
+++ b/web/war/src/main/webapp/test/unit/mocks/ontologyPromise.js
@@ -68,7 +68,6 @@ define(['util/promise'], function() {
                 properties:[]
             });
 
-            // Add video sub concept to test compound properties
             ontologyJson.concepts.push({
                 id:'http://visallo.org/dev#personSub',
                 title:'http://visallo.org/dev#personSub',
@@ -78,6 +77,33 @@ define(['util/promise'], function() {
                 searchable:true,
                 properties:[]
             });
+
+            ontologyJson.concepts.push({
+                id:'http://visallo.org/dev#formulaTestConcept',
+                title:'http://visallo.org/dev#formulaTestConcept',
+                displayName:'FormulaTestConcept',
+                parentConcept:'http://visallo.org#root',
+                pluralDisplayName:'FormulaTestConcepts',
+                titleFormula: 'ontology.displayName',
+                properties:[]
+            })
+
+            ontologyJson.concepts.push({
+                id:'http://visallo.org/dev#formulaTest',
+                title:'http://visallo.org/dev#formulaTest',
+                displayName:'FormulaTest',
+                parentConcept:'http://visallo.org#root',
+                pluralDisplayName:'FormulaTests',
+                titleFormula: `String(
+                    typeof prop === "function" &&
+                    typeof propRaw === "function" &&
+                    typeof longestProp === "function" &&
+                    typeof ontology === "object" &&
+                    typeof vertex === 'object' &&
+                    typeof edge === 'undefined'
+                )`,
+                properties:[]
+            })
 
             window.ONTOLOGY_JSON = ontologyJson;
             require(['data/web-worker/services/ontology'], function(ontology) {

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -37,7 +37,7 @@ define([
         COMPOUND_TEST_PROPERTY_NAME = 'http://visallo.org/testing#compound1',
 
         keyIdent = 0,
-        vertexIdent = 0,
+        elementIdent = 0,
         addMetadata = function(property, key, value) {
             var newProp = _.extend({}, property);
             if (!newProp.metadata) {
@@ -69,11 +69,11 @@ define([
                 id = null;
             }
             return {
-                id: id || ('testVertex' + vertexIdent++),
+                id: id || `testVertex-${elementIdent++}`,
                 properties: properties || [],
                 type: 'vertex'
             }
-        }
+        };
 
     describe('vertex formatters', function() {
 
@@ -521,7 +521,21 @@ define([
                         propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
                     ]);
 
-                expect(V.title(vertex)).to.equal('harwig, jason')
+                V.title(vertex).should.equal('harwig, jason')
+            })
+
+            it('Concept should be available to formulas for vertices', function() {
+                var vertex = vertexFactory([
+                    propertyFactory(PROPERTY_NAME_CONCEPT, '', 'http://visallo.org/dev#formulaTestConcept')
+                ])
+                V.title(vertex).should.equal('FormulaTestConcept')
+            })
+
+            it('Check for scope vars in formula', function() {
+                var vertex = vertexFactory([
+                    propertyFactory(PROPERTY_NAME_CONCEPT, '', 'http://visallo.org/dev#formulaTest')
+                ])
+                V.title(vertex).should.equal('true')
             })
         })
 


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Allows use of `ontology.displayName` in subtitle formulas for nicer default
element lists.

Testing Instructions: Add `ontology.displayName` to some concepts `subtitleFormula`. Run a search, you should see the concept type below the title.

CHANGELOG
Added: `ontology` now available in scope for `titleFormula`, `subtitleFormula` and `timeFormula` which is a JSON object of the concept/relationship of the element