### PR TITLE
Fix image selection box and resolution(3.1.3)

### DIFF
--- a/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
+++ b/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
@@ -150,26 +150,32 @@ define([
             var self = this;
 
             require(['../dropdowns/termForm/termForm'], function(TermForm) {
-                self.$node.show().find('.underneath').teardownComponent(TermForm);
-                var root = $('<div class="underneath">');
+                const $form = self.$node.show().find('.underneath');
+                const termForm = $form.lookupComponent(TermForm);
 
-                if (data.property) {
-                    root.appendTo(self.node);
-                } else {
-                    root.prependTo(self.node);
+                if (!termForm || (data.property && data.property.key) !== termForm.attr.dataInfo.originalPropertyKey) {
+                    $form.teardownComponent(TermForm);
+
+                    const root = $('<div class="underneath">');
+
+                    if (data.property) {
+                        root.appendTo(self.node);
+                    } else {
+                        root.prependTo(self.node);
+                    }
+
+                    TermForm.attachTo(root, {
+                        artifactData: self.model,
+                        dataInfo: _.extend({}, data.property, {
+                            originalPropertyKey: data.property && data.property.key,
+                            title: data.title
+                        }, data.value),
+                        restrictConcept: data.value.concept,
+                        existing: Boolean(data.property && data.property.resolvedVertexId),
+                        detectedObject: true,
+                        unresolve: data.unresolve || false
+                    });
                 }
-
-                TermForm.attachTo(root, {
-                    artifactData: self.model,
-                    dataInfo: _.extend({}, data.property, {
-                        originalPropertyKey: data.property && data.property.key,
-                        title: data.title
-                    }, data.value),
-                    restrictConcept: data.value.concept,
-                    existing: Boolean(data.property && data.property.resolvedVertexId),
-                    detectedObject: true,
-                    unresolve: data.unresolve || false
-                });
             })
         };
 

--- a/web/war/src/main/webapp/js/menubar/menubar.js
+++ b/web/war/src/main/webapp/js/menubar/menubar.js
@@ -221,7 +221,7 @@ define([
             })
             $(document).on('dragstart', function(event) {
                 const dataTransfer = event.originalEvent.dataTransfer;
-                if (!$('.products-pane.visible').length) {
+                if (dataTransfer && !$('.products-pane.visible').length) {
                     if (_.any(dataTransfer.types, type => type === VISALLO_MIMETYPES.ELEMENTS)) {
                         const cls = 'hint-drop-normal';
                         const node = $('.menubar-pane .products a').addClass(cls);


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [ ] joeybrk372 rygim jharwig EvanOxfeld

We flash the product menu bar icon when dragging data, which was failing when trying to drag the image selection box.

Also fixed an issue with the resolved edge creation and the detected objects form getting torn down every time you moved/resized the selection box. Now the form will only update if the object is changed.

Testing Instructions: Resolve/unresolve detected objects and your own selections. You should be able to switch between detected objects and resolving new selections.

CHANGELOG
Fixed: Image selection box could not be moved if the Work Products List was closed.
Fixed: Image object resolution form no longer reopens every time you resize/move the selection box.
Fixed: Resolving object would sometimes fail.
