### PR TITLE
Only allow analytics to be sent from intended domains

### DIFF
--- a/docs/book.js
+++ b/docs/book.js
@@ -11,7 +11,10 @@ module.exports = {
   },
   pluginsConfig: {
     ga: {
-        token: 'UA-63006144-4'
+        token: 'UA-63006144-4',
+        configuration: {
+            cookieDomain: 'docs.visallo.org'
+        }
     },
     lunr: {
         maxIndexSize: 1000000000


### PR DESCRIPTION
Our analytics are currently being skewed by traffic from localhost development environments.