### PR TITLE
Changed: OWL Import: Compare the previous ontology MD5 and skip import if it has not changed

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyProperties.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyProperties.java
@@ -10,6 +10,7 @@ public class OntologyProperties {
 
     public static final StringSingleValueVisalloProperty TITLE = new StringSingleValueVisalloProperty("http://visallo.org#title");
     public static final StreamingVisalloProperty ONTOLOGY_FILE = new StreamingVisalloProperty("http://visallo.org#ontologyFile");
+    public static final StringVisalloProperty ONTOLOGY_FILE_MD5 = new StringVisalloProperty("http://visallo.org#ontologyFileMd5");
     public static final IntegerSingleValueVisalloProperty DEPENDENT_PROPERTY_ORDER_PROPERTY_NAME = new IntegerSingleValueVisalloProperty("order");
     public static final StringVisalloProperty TEXT_INDEX_HINTS = new StringVisalloProperty("http://visallo.org#textIndexHints");
     public static final StringSingleValueVisalloProperty ONTOLOGY_TITLE = new StringSingleValueVisalloProperty("http://visallo.org#ontologyTitle");

--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -248,6 +248,10 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
             File inDir,
             Authorizations authorizations
     ) throws Exception {
+        if (!hasFileChanged(documentIRI, inFileData)) {
+            LOGGER.info("skipping %s, file has not changed", documentIRI);
+            return;
+        }
         Reader inFileReader = new InputStreamReader(new ByteArrayInputStream(inFileData));
 
         OWLOntologyLoaderConfiguration config = new OWLOntologyLoaderConfiguration();
@@ -298,6 +302,10 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
         storeOntologyFile(new ByteArrayInputStream(inFileData), documentIRI);
 
         clearCache();
+    }
+
+    protected boolean hasFileChanged(IRI documentIRI, byte[] inFileData) {
+        return true;
     }
 
     private void importInverseOfObjectProperties(OWLOntology o) {


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Importing OWL files creates lots of history and takes time to prevent this store
the MD5 and only re-import it when the MD5 has changed

Testing Instructions:
- Start the application with an OWL file defined in the configuration
- Restart the application, the OWL file should be skipped
- Change the OWL file
- Restart the application, the OWL file should import the new changes

CHANGELOG
Changed: OWL Import: Compare the previous ontology MD5 and skip import if it has not changed
