### PR TITLE
Changed: Upgrade to Vertexium 2.5.6

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -78,7 +78,7 @@
         <lesscss.version>1.3.3</lesscss.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <vertexium.version>2.5.4</vertexium.version>
+        <vertexium.version>2.5.6</vertexium.version>
         <simple-orm.version>1.3.0</simple-orm.version>
         <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions:
- Vertexium 2.5.6 deals with streaming property values. It removes the timestamp from the row id. Best way to test is by looking at the size of accumulo data table using "du" in the accumulo shell. Then create lots of new graph product previews by moving nodes on the graph and allowing the preview image to update. After doing this for a while the disk usage of the data table should not increase by a lot since it will not keep many many versions of history anymore.

CHANGELOG
Changed: Upgrade to Vertexium 2.5.6
