### PR TITLE
Changes required for Vertexium 2.6.x

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerWithRelatedBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerWithRelatedBase.java
@@ -53,7 +53,7 @@ public abstract class ElementSearchRunnerWithRelatedBase extends ElementSearchRu
         } else if (relatedToVertexIds.size() == 1) {
             graphQuery = query(queryString, relatedToVertexIds.get(0), authorizations);
         } else {
-            graphQuery = new CompositeGraphQuery(Lists.transform(
+            graphQuery = new CompositeGraphQuery(getGraph(), Lists.transform(
                     relatedToVertexIds,
                     relatedToVertexId -> query(queryString, relatedToVertexId, authorizations)
             ));

--- a/core/plugins/model-vertexium-elasticsearch/src/main/java/org/visallo/vertexium/es/IriIndexSelectionStrategyBase.java
+++ b/core/plugins/model-vertexium-elasticsearch/src/main/java/org/visallo/vertexium/es/IriIndexSelectionStrategyBase.java
@@ -2,18 +2,20 @@ package org.visallo.vertexium.es;
 
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.vertexium.*;
-import org.vertexium.elasticsearch.ElasticSearchElementType;
+import org.vertexium.elasticsearch.DefaultIndexSelectionStrategy;
 import org.vertexium.elasticsearch.ElasticSearchSingleDocumentSearchQueryBase;
+import org.vertexium.elasticsearch.ElasticsearchDocumentType;
 import org.vertexium.elasticsearch.ElasticsearchSingleDocumentSearchIndex;
-import org.vertexium.elasticsearch.IndexSelectionStrategy;
 import org.vertexium.query.QueryBase;
 import org.visallo.core.model.properties.VisalloProperties;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class IriIndexSelectionStrategyBase implements IndexSelectionStrategy {
+@Deprecated
+public abstract class IriIndexSelectionStrategyBase extends DefaultIndexSelectionStrategy {
     public static final String INDEX_NAME_PREFIX = "indexNamePrefix";
     public static final String DEFAULT_INDEX_NAME_PREFIX = "visallo_";
     private static final String DEFAULT_INDEX_SUFFIX = "default";
@@ -22,6 +24,7 @@ public abstract class IriIndexSelectionStrategyBase implements IndexSelectionStr
     private Map<String, String> iriToIndexNameCache = new HashMap<>();
 
     public IriIndexSelectionStrategyBase(GraphConfiguration config) {
+        super(config);
         indexPrefix = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + INDEX_NAME_PREFIX, DEFAULT_INDEX_NAME_PREFIX);
         indiciesToQuery = new String[]{
                 indexPrefix + "*"
@@ -79,7 +82,7 @@ public abstract class IriIndexSelectionStrategyBase implements IndexSelectionStr
     }
 
     @Override
-    public String[] getIndicesToQuery(ElasticSearchSingleDocumentSearchQueryBase query, ElasticSearchElementType elementType) {
+    public String[] getIndicesToQuery(ElasticSearchSingleDocumentSearchQueryBase query, EnumSet<ElasticsearchDocumentType> elementType) {
         for (QueryBase.HasContainer hasContainer : query.getParameters().getHasContainers()) {
             if (hasContainer instanceof QueryBase.HasValueContainer) {
                 QueryBase.HasValueContainer hasValueContainer = (QueryBase.HasValueContainer) hasContainer;

--- a/core/plugins/model-vertexium-elasticsearch/src/main/java/org/visallo/vertexium/es/SimpleVisalloIndexSelectionStrategy.java
+++ b/core/plugins/model-vertexium-elasticsearch/src/main/java/org/visallo/vertexium/es/SimpleVisalloIndexSelectionStrategy.java
@@ -1,9 +1,13 @@
 package org.visallo.vertexium.es;
 
+import org.vertexium.Element;
+import org.vertexium.ExtendedDataRowId;
 import org.vertexium.GraphConfiguration;
+import org.vertexium.elasticsearch.ElasticsearchSingleDocumentSearchIndex;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workspace.WorkspaceRepository;
 
+@Deprecated
 public class SimpleVisalloIndexSelectionStrategy extends IriIndexSelectionStrategyBase {
     public SimpleVisalloIndexSelectionStrategy(GraphConfiguration config) {
         super(config);
@@ -23,5 +27,15 @@ public class SimpleVisalloIndexSelectionStrategy extends IriIndexSelectionStrate
             return encodeIndexName("workspace");
         }
         return encodeIndexName("vertex");
+    }
+
+    @Override
+    public String getExtendedDataIndexName(ElasticsearchSingleDocumentSearchIndex es, Element element, String tableName, String rowId) {
+        return encodeIndexName("extdata_" + tableName);
+    }
+
+    @Override
+    public String getExtendedDataIndexName(ElasticsearchSingleDocumentSearchIndex es, ExtendedDataRowId rowId) {
+        return encodeIndexName("extdata_" + rowId.getTableName());
     }
 }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -276,15 +276,12 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
         checkNotNull(rootConceptVertex, "Could not get root concept vertex");
 
         List<Property> ontologyFiles = Lists.newArrayList(OntologyProperties.ONTOLOGY_FILE.getProperties(rootConceptVertex));
-        Collections.sort(ontologyFiles, new Comparator<Property>() {
-            @Override
-            public int compare(Property ontologyFile1, Property ontologyFile2) {
-                Integer index1 = (Integer) ontologyFile1.getMetadata().getValue("index");
-                checkNotNull(index1, "Could not find metadata (1) 'index' on " + ontologyFile1);
-                Integer index2 = (Integer) ontologyFile2.getMetadata().getValue("index");
-                checkNotNull(index2, "Could not find metadata (2) 'index' on " + ontologyFile2);
-                return index1.compareTo(index2);
-            }
+        ontologyFiles.sort((ontologyFile1, ontologyFile2) -> {
+            Integer index1 = (Integer) ontologyFile1.getMetadata().getValue("index");
+            checkNotNull(index1, "Could not find metadata (1) 'index' on " + ontologyFile1);
+            Integer index2 = (Integer) ontologyFile2.getMetadata().getValue("index");
+            checkNotNull(index2, "Could not find metadata (2) 'index' on " + ontologyFile2);
+            return index1.compareTo(index2);
         });
         return ontologyFiles;
     }

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -78,7 +78,7 @@
         <lesscss.version>1.3.3</lesscss.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <vertexium.version>2.5.6</vertexium.version>
+        <vertexium.version>2.6.0</vertexium.version>
         <simple-orm.version>1.3.0</simple-orm.version>
         <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>
@@ -103,7 +103,7 @@
         <dbcp2.version>2.1.1</dbcp2.version>
         <jdbi.version>2.63.1</jdbi.version>
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
-        <handlebars.version>1.0.0</handlebars.version>
+        <handlebars.version>4.0.6</handlebars.version>
         <javax.mail.version>1.4.5</javax.mail.version>
         <uadetector.resources.version>2014.06</uadetector.resources.version>
         <mysql.version>5.1.38</mysql.version>
@@ -588,6 +588,11 @@
                 <artifactId>vertexium-test</artifactId>
                 <version>${vertexium.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.vertexium</groupId>
+                <artifactId>vertexium-cypher</artifactId>
+                <version>${vertexium.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.vertexium</groupId>

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
@@ -48,7 +48,7 @@ public abstract class ElementSearchBase {
     ) throws Exception {
         SearchOptions searchOptions = WebSearchOptionsFactory.create(request, workspaceId);
         try (QueryResultsIterableSearchResults searchResults = this.searchRunner.run(searchOptions, user, authorizations)) {
-            Map<String, Double> scores = null;
+            Map<Object, Double> scores = null;
             if (searchResults.getQueryResultsIterable() instanceof IterableWithScores) {
                 scores = ((IterableWithScores<?>) searchResults.getQueryResultsIterable()).getScores();
             }
@@ -201,7 +201,7 @@ public abstract class ElementSearchBase {
     protected List<ClientApiElement> convertElementsToClientApi(
             ElementSearchRunnerBase.QueryAndData queryAndData,
             Iterable<? extends Element> searchResults,
-            Map<String, Double> scores,
+            Map<Object, Double> scores,
             String workspaceId,
             Authorizations authorizations
     ) {


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [ ] mwizeman sfeng88
- [ ] joeybrk372 rygim jharwig EvanOxfeld

Requires a new docker image with 2.6.0 iterators (https://github.com/visallo/visallo-lts/pull/2720)

CHANGELOG
Changed: Vertexium 2.6.0
Deprecated: IriIndexSelectionStrategyBase and SimpleVisalloIndexSelectionStrategy