### PR TITLE
Graph extension point caching

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -227,7 +227,7 @@ define([
                 if (initialProductDisplay && !hasViewport) return true;
                 const wasEmpty = oldNodes.length === 0;
                 const hasNodes = newNodes.length
-                const positionIsEmpty = node => node.position.x === 0 && node.position.y === 0;
+                const positionIsEmpty = node => !node.position || (node.position.x === 0 && node.position.y === 0);
 
                 if (wasEmpty && hasNodes) {
                     return _.every(newNodes, positionIsEmpty);

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/_setup.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/_setup.js
@@ -1,0 +1,7 @@
+import bluebird from 'bluebird'
+import underscore from 'underscore'
+
+
+global.Promise = bluebird
+global._ = underscore
+

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/_setup.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/_setup.js
@@ -4,4 +4,5 @@ import underscore from 'underscore'
 
 global.Promise = bluebird
 global._ = underscore
+if (!Object.values) Object.values = _.values
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/components/Attacher.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/components/Attacher.jsx
@@ -1,0 +1,3 @@
+export default {
+    attachTo: () => {}
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/popovers.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/popovers.js
@@ -1,0 +1,1 @@
+export default {}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/formatters.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/formatters.js
@@ -1,5 +1,8 @@
 export default {
     number: {
         pretty: num => 'pretty: ' + num
+    },
+    string: {
+        truncate: str => str
     }
 }

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/retina.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/retina.js
@@ -1,2 +1,5 @@
 export default {
+    pixelRatio: 1,
+    pointsToPixels: p => p,
+    pixelsToPoints: p => p
 }

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/vertexFormatters.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/util/vertexFormatters.js
@@ -1,2 +1,14 @@
-export default {
-}
+import formatters from './formatters'
+import _ from 'underscore'
+
+export default Object.assign({}, formatters, {
+    vertex: {
+        title: v => v.id,
+        prop: (v, name) => {
+            const p = _.findWhere(v.properties, { name });
+            return p ? p.value : null
+        },
+        image: v => undefined,
+        selectedImage: v => undefined
+    }
+})

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__tests__/Graph.test.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__tests__/Graph.test.jsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import Graph from '../Graph'
+import renderer from 'react-test-renderer'
+import ReactTestUtils from 'react-dom/lib/ReactTestUtils'
+import bluebird from 'bluebird'
+import updeep from 'updeep'
+
+it('Should only call extension functions on vertex changes', () => {
+    let counters = {}
+    const increment = (name, id) => {
+        if (!counters[name]) {
+            counters[name] = {}
+        }
+        if (!counters[name][id]) {
+            counters[name][id] = 1
+        } else {
+            counters[name][id]++
+        }
+    }
+    const count = (name, returnVal) => el => {
+        if (_.isArray(el)) {
+            increment(name, el[0].label);
+        } else if (el.edges) {
+            increment(name, el.type);
+        } else {
+            increment(name, el.id);
+        }
+        return returnVal;
+    }
+    const getCount = (name, elementId) => counters[name] && counters[name][elementId] || 0
+    const assertCounts = (expected, numbers = [1, 2]) => {
+        Object.keys(expected).forEach(id => {
+            expect(expected[id] >= 0).toBe(true);
+
+            numbers.forEach(num => {
+                if (/^v/.test(id)) {
+                    expect(getCount('applyTo-'+num, id)).toBe(expected[id])
+                    expect(getCount('class-'+num, id)).toBe(expected[id])
+                    expect(getCount('data-'+num, id)).toBe(expected[id])
+                    expect(getCount('transform-'+num, id)).toBe(expected[id])
+                } else {
+                    expect(expected[id] >= 0).toBe(true)
+                    expect(getCount('edgeClass-'+num, id)).toBe(expected[id])
+                    expect(getCount('edgeTransform-'+num, id)).toBe(expected[id])
+                }
+            })
+        })
+    }
+    const renderer = ReactTestUtils.createRenderer()
+    let props = {
+        workspace: { editable: true },
+        uiPreferences: { },
+        product: { extendedData: { vertices: [], edges: ['e1', 'e2'] } },
+        productElementIds: {
+            vertices: [
+                { id:'v1', pos: {x:0,y:0} },
+                { id:'v2', pos: {x:0,y:0} }
+            ],
+            edges: [
+                { edgeId:'e1', label: 'e1Label', inVertexId: 'v2', outVertexId: 'v1'  },
+                { edgeId:'e2', label: 'e2Label', inVertexId: 'v2', outVertexId: 'v1'  },
+                { edgeId:'e3', label: 'e2Label', inVertexId: 'v2', outVertexId: 'v1'  }
+            ]
+        },
+        ontology: { relationships: { } },
+        elements: {
+            vertices: {
+                'v1': { id: 'v1', properties: [] },
+                'v2': { id: 'v2', properties: [] }
+            }, edges: {
+                'e1': { id: 'e1', label: 'e1Label', properties: [] },
+                'e2': { id: 'e2', label: 'e2Label', properties: [] },
+                'e3': { id: 'e3', label: 'e2Label', properties: [] }
+            }
+        },
+        selection: { vertices: [], edges: [] },
+        focusing: { vertices: [], edges: [] },
+        registry: {
+            'org.visallo.graph.view': [],
+            'org.visallo.graph.style': [],
+            'org.visallo.graph.options': [],
+            'org.visallo.graph.edge.class': [
+                count('edgeClass-1', ''),
+                count('edgeClass-2', '')
+            ],
+            'org.visallo.graph.edge.transformer': [
+                count('edgeTransform-1', {}),
+                count('edgeTransform-2', {})
+            ],
+            'org.visallo.graph.node.class': [
+                count('class-1', ''), count('class-2', '')
+            ],
+            'org.visallo.graph.node.transformer': [
+                count('transform-1', {}), count('transform-2', {})
+            ],
+            'org.visallo.graph.node.decoration': [
+                { applyTo: count('applyTo-1', true), data: count('data-1', {}) },
+                { applyTo: count('applyTo-2', true), data: count('data-2', {}) }
+            ]
+        },
+        onUpdatePreview: () => {}
+    }
+
+    // Initial Render all called once
+    renderer.render(<Graph {...props} />)
+    assertCounts({ v1: 1, v2: 1, e1Label: 1, e2Label: 1 })
+
+    // Change some other prop to re-render, but no functions should have been called
+    renderer.render(<Graph {...props} panelPadding='new' />)
+    assertCounts({ v1: 1, v2: 1, e1Label: 1, e2Label: 1 })
+
+    // Change v2, e2 and re-render, only v2, e2 should update
+    const changeElements = {
+        vertices: {
+            v1: props.elements.vertices.v1,
+            v2: { id: 'v2', properties: [] }
+        },
+        edges: {
+            e1: props.elements.edges.e1,
+            e2: { id: 'e2', label: 'e2Label', properties: [] },
+            e3: props.elements.edges.e3
+        }
+    };
+    renderer.render(<Graph {...props} elements={changeElements} />)
+    assertCounts({ v1: 1, v2: 2, e1Label: 1, e2Label: 2 })
+
+
+    const add = item => {
+        return (list) => {
+            return list.concat([item])
+        }
+    };
+    const changeRegistry = updeep({
+        'org.visallo.graph.edge.class': add(count('edgeClass-3', '')),
+        'org.visallo.graph.edge.transformer': add(count('edgeTransform-3', {})),
+        'org.visallo.graph.node.class': add(count('class-3', '')),
+        'org.visallo.graph.node.transformer': add(count('transform-3', {})),
+        'org.visallo.graph.node.decoration': add({ applyTo: count('applyTo-3', true), data: count('data-3', {}) })
+    }, props.registry)
+    renderer.render(<Graph {...props} elements={changeElements} registry={changeRegistry} />)
+    assertCounts({ v1: 2, v2: 3, e1Label: 2, e2Label: 3 })
+    assertCounts({ v1: 1, v2: 1, e1Label: 1, e2Label: 1 }, [3])
+
+    renderer.render(<Graph {...props} elements={changeElements} registry={changeRegistry} />)
+    assertCounts({ v1: 2, v2: 3, e1Label: 2, e2Label: 3 })
+    assertCounts({ v1: 1, v2: 1, e1Label: 1, e2Label: 1 }, [3])
+})

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
@@ -23,24 +23,30 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
+    "bluebird": "^3.5.0",
     "color-js": "1.0.3",
     "ejs-compiled-loader": "^1.1.0",
     "fast-json-patch": "1.0.0",
     "jest": "^18.1.0",
     "react": "15.4.2",
-    "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
     "react-test-renderer": "15.4.2",
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.2",
     "redux-thunk": "^2.2.0",
     "underscore": "1.8.3",
+    "updeep": "^1.0.0",
     "webpack": "^1.14.0"
   },
   "jest": {
+    "setupFiles": [
+      "<rootDir>/__mocks__/_setup.js"
+    ],
     "moduleNameMapper": {
       "components/NavigationControls": "<rootDir>/__mocks__/components/NavigationControls.jsx",
       "components/RegistryInjectorHOC": "<rootDir>/__mocks__/components/RegistryInjectorHOC.jsx",
+      "components/Attacher": "<rootDir>/__mocks__/components/Attacher.jsx",
+      "popovers/index": "<rootDir>/__mocks__/popovers.js",
       "data/web-worker/store/actions": "<rootDir>/__mocks__/data/web-worker/store/actions.js",
       "data/web-worker/store/element/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/element/actions-impl.js",
       "data/web-worker/store/product/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/product/actions-impl.js",

--- a/web/war/src/main/webapp/js/components/RegistryInjectorHOC.jsx
+++ b/web/war/src/main/webapp/js/components/RegistryInjectorHOC.jsx
@@ -8,7 +8,7 @@ define([
     const RegistryInjectorHOC = (WrappedComponent, identifiers) => {
         if (!_.isArray(identifiers)) throw new Error('identifiers must be an array');
 
-        return React.createClass({
+        const WithRegistry = React.createClass({
             displayName: `RegistryInjectorHOC(${WrappedComponent.displayName || 'Component'})`,
             componentDidMount() {
                 if (identifiers.length === 0) {
@@ -24,10 +24,11 @@ define([
                 $(document).off('extensionsChanged.registryInjector');
             },
             render() {
-                const registrySubset = _.object(identifiers.map(i => [i, registry.extensionsForPoint(i)]));
-                return (<WrappedComponent ref="wrapped" {...this.props} registry={registrySubset} />);
+                return (<WrappedComponent {...this.props} registry={registry.extensionsForPoints(identifiers)} />);
             }
         })
+
+        return WithRegistry;
     };
 
     RegistryInjectorHOC.registry = registry;

--- a/web/war/src/main/webapp/test/unit/spec/configuration/plugins/registryTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/configuration/plugins/registryTest.js
@@ -24,6 +24,42 @@ define(['configuration/plugins/registry'], function(registry) {
             registry.extensionsForPoint('a').length.should.equal(0)
         })
 
+        it('should be able to request the same subset', function() {
+            registry.registerExtension('a', 'A')
+            registry.registerExtension('b', 'B')
+            registry.registerExtension('c', 'C')
+
+            registry.documentExtensionPoint('a', 'desc', () => true)
+            registry.documentExtensionPoint('b', 'desc', () => true)
+            registry.documentExtensionPoint('c', 'desc', () => false)
+
+            const r = registry.extensionsForPoints(['a', 'b', 'c'])
+            r.should.deep.equal({ a: ['A'], b: ['B'], c: [] })
+            r.should.equal(registry.extensionsForPoints(['a', 'b', 'c']))
+
+            registry.registerExtension('d', 'D')
+            registry.documentExtensionPoint('d', 'desc', () => true)
+            r.should.equal(registry.extensionsForPoints(['b', 'a', 'c']))
+        })
+        
+        it('should return the same object when asking twice and no change', function() {
+            registry.registerExtension('a', 'AA')
+            const beforeDoc = registry.extensionsForPoint('a')
+            registry.documentExtensionPoint('a', 'desc', () => true)
+            const afterDoc = registry.extensionsForPoint('a')
+            const afterDoc2 = registry.extensionsForPoint('a')
+            beforeDoc.should.not.equal(afterDoc)
+            afterDoc.should.equal(afterDoc2)
+
+            registry.registerExtension('b', 'BB')
+            registry.documentExtensionPoint('b', 'desc', () => true)
+            const initialB = registry.extensionsForPoint('b')
+            initialB.should.equal(registry.extensionsForPoint('b'))
+
+            const afterB = registry.extensionsForPoint('a')
+            afterDoc.should.equal(afterB)
+        })
+
         it('should throw error when extension point is not provided', function() {
             expect(registry.registerExtension).to.throw('extension')
             expect(function() {


### PR DESCRIPTION
- [x] joeferner
- [ ] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

For the following extension points don't call the functions until the vertex or registry changes:

* org.visallo.graph.edge.class
* org.visallo.graph.edge.transformer
* org.visallo.graph.node.class
* org.visallo.graph.node.transformer
* org.visallo.graph.node.decoration (applyTo and data)

Previously some state changes (like a selection or opening a panel) would cause all these extension point functions to re-evaluate.

Needed to change the registry to be non-mutated state for simple comparisons, and added some tests to both graph and registry.

Added benefit is new the `RegistryInjectorHOC` now won't trigger a
re-render unless the subscribed to registry changes


Testing Instructions: Register extensions of the above types. Use doc-examples repo for samples.

Points of Regression: None

CHANGELOG
Fixed: Certain graph extension points would get invoked more often than necessary causing slowdowns with large graphs.
