### PR TITLE
Don't assume visibility metadata when mapping properties in saved search table(master)

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/Card.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/Card.jsx
@@ -359,11 +359,9 @@ define([
                         const values = [];
                         const ontologyProperty = ontologyProperties.byTitle[title];
                         const isCompoundField = !!ontologyProperty.dependentPropertyIris;
-                        const properties = _.uniq(F.vertex.props(result, title), function(property) {
-                            let identifier = property.key + property.metadata['http://visallo.org#visibilityJson'].source;
-                            if (!isCompoundField) identifier += property.name;
-                            return identifier;
-                        });
+                        const properties = _.uniq(F.vertex.props(result, title), (property) => (
+                            isCompoundField ? property.key : (property.key + property.name)
+                        ));
                         let propertiesPromise;
 
                         if (properties.length) {


### PR DESCRIPTION
https://github.com/visallo/visallo/pull/1144