### PR TITLE
Allow passing `size` parameter in term aggregation

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -134,7 +134,12 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
 
     private Aggregation getTermsAggregation(String aggregationName, JSONObject aggregateJson) {
         String field = aggregateJson.getString("field");
-        return new TermsAggregation(aggregationName, field);
+        TermsAggregation terms = new TermsAggregation(aggregationName, field);
+        int size = aggregateJson.optInt("size", 0);
+        if (size > 0) {
+            terms.setSize(size);
+        }
+        return terms;
     }
 
     private Aggregation getGeohashAggregation(String aggregationName, JSONObject aggregateJson) {


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

...to specify the number of buckets returned

Testing Instructions: No user-facing testing

Points of Regression: None

CHANGELOG
Added: Search term aggregations can now include a `size` parameter to specify the number of buckets returned. Route-only, no UI configuration for sizes.
