### PR TITLE
Fix tomcat not showing file too large dialog for files exceeding limit.

### DIFF
--- a/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
+++ b/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
@@ -38,7 +38,14 @@ public class TomcatWebServer extends WebServer {
         Connector httpsConnector = new Connector(Http11NioProtocol.class.getName());
         setupSslHandling(httpsConnector);
         setupClientCertHandling(httpsConnector);
-        setupCompression(httpsConnector);
+
+        ProtocolHandler handler = httpsConnector.getProtocolHandler();
+        if (handler instanceof AbstractHttp11Protocol) {
+            AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+            setupCompression(protocol);
+            protocol.setMaxSwallowSize(-1);
+        }
+
 
         tomcat = new Tomcat();
         tomcat.setPort(super.getHttpPort());
@@ -104,13 +111,10 @@ public class TomcatWebServer extends WebServer {
         LOGGER.info("clientAuth certificate handling set to %s", clientAuthSetting);
     }
 
-    public void setupCompression(Connector connector) {
-        ProtocolHandler handler = connector.getProtocolHandler();
-        if (handler instanceof AbstractHttp11Protocol) {
-            AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) handler;
-            protocol.setCompression("on");
-            protocol.setCompressableMimeType(COMPRESSABLE_MIME_TYPES);
-            LOGGER.info("compression set for mime types: %s", COMPRESSABLE_MIME_TYPES);
-        }
+    public void setupCompression(AbstractHttp11Protocol<?> protocol) {
+        protocol.setCompression("on");
+        protocol.setCompressableMimeType(COMPRESSABLE_MIME_TYPES);
+        protocol.setMaxSwallowSize(-1);
+        LOGGER.info("compression set for mime types: %s", COMPRESSABLE_MIME_TYPES);
     }
 }

--- a/web/war/src/main/webapp/js/util/withFormFieldErrors.js
+++ b/web/war/src/main/webapp/js/util/withFormFieldErrors.js
@@ -31,7 +31,9 @@ define(['tpl!./alert'], function(alertTemplate) {
                 }
             } catch(e) { /*eslint no-empty:0 */ }
 
-            if (_.isObject(error)) {
+            if (_.isError(error)) {
+                messages.push(error.message)
+            } else if (_.isObject(error)) {
                 _.keys(error).forEach(function(fieldName) {
                     switch (fieldName) {
                         case 'status': break;
@@ -66,12 +68,15 @@ define(['tpl!./alert'], function(alertTemplate) {
                             break;
                     }
                 });
-            } else {
-                messages.push(error || 'Unknown error');
+            } else if (_.isString(error) && error) {
+                messages.push(error);
+            }
+
+            if (!messages.length) {
+                messages.push('Unknown error')
             }
 
             var errorsContainer = rootEl.find('.errors');
-
             if (errorsContainer.length) {
                 errorsContainer.html(
                     alertTemplate({


### PR DESCRIPTION
- [x] joeferner
- [x] diegogrz
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Set `maxSwallowSize` so the error message is correctly returned to the
server, otherwise tomcat just resets the connection and no reason is
sent

Also be more graceful in printing something in the error dialog.

Testing Instructions: Upload a file that is over 50MB, should get an error message

Points of Regression: Will upload the whole file before an error.

CHANGELOG
Fixed: Error message shown when uploading files over the limit.