### PR TITLE
Changed: keep search results when reopening the search pane

### DIFF
--- a/web/war/src/main/webapp/js/search/types/withSearch.js
+++ b/web/war/src/main/webapp/js/search/types/withSearch.js
@@ -69,7 +69,7 @@ define([
                 }
             });
             this.on('clearSearch', function(event, data) {
-                this.hideSearchResults();
+                this.hideAndClearSearchResults();
 
                 var filters = this.select('filtersSelector').find('.content')
                 this.trigger(filters, 'clearfilters', data);
@@ -83,8 +83,14 @@ define([
         });
 
         this.onToggleDisplay = function(event, data) {
-            if (data.name === 'search' && this.$node.closest('.visible').length === 0) {
-                this.hideSearchResults();
+            if (data.name === 'search') {
+                if (this.$node.closest('.visible').length === 0) {
+                    this.hideSearchResults();
+                } else {
+                    if (this.select('resultsContainerSelector').html().length > 0) {
+                        this.showSearchResults();
+                    }
+                }
             }
         };
 
@@ -113,12 +119,24 @@ define([
             });
         };
 
-        this.hideSearchResults = function() {
+        this.hideAndClearSearchResults = function() {
+            return this.hideSearchResults(true);
+        };
+
+        this.hideSearchResults = function(clear) {
             this.select('resultsSelector')
                 .hide();
-            this.select('resultsContainerSelector')
-                .teardownAllComponents()
-                .empty();
+            if (clear) {
+                this.select('resultsContainerSelector')
+                    .teardownAllComponents()
+                    .empty();
+            }
+            this.trigger(document, 'paneResized');
+        };
+
+        this.showSearchResults = function() {
+            this.select('resultsSelector')
+                .show();
             this.trigger(document, 'paneResized');
         };
 


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Previously a user would need to rerun the search, on complex searches
this could take a while. This change allows the user to close the search
pane and reopen and retain their search results.

Testing Instructions:
- Open the search and find something
- Close the search pane using the "ESC" key (or click the find button again)
- Reopen the search pane, the results should be there

CHANGELOG
Changed: keep search results when reopening the search pane
