### PR TITLE
Changed: Don't use isOntologyDefined to protect double loading ontologies

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepository.java
@@ -128,6 +128,11 @@ public interface OntologyRepository {
 
     String getRequiredPropertyIRIByIntent(String intent);
 
+    /**
+     * This method was used to avoid reimporting ontologies. It is no longer needed since MD5s of imported ontologies
+     * will be kept and if an ontology has not changed it will not be imported again.
+     */
+    @Deprecated
     boolean isOntologyDefined(String iri);
 
     OntologyProperty getDependentPropertyParent(String iri);

--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -141,11 +141,6 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
 
     @Override
     public void importResourceOwl(Class baseClass, String fileName, String iri, Authorizations authorizations) {
-        if (isOntologyDefined(iri)) {
-            LOGGER.debug("Ontology %s (iri: %s) is already defined", fileName, iri);
-            return;
-        }
-
         LOGGER.debug("importResourceOwl %s (iri: %s)", fileName, iri);
         InputStream owlFileIn = baseClass.getResourceAsStream(fileName);
         checkNotNull(owlFileIn, "Could not load resource " + baseClass.getResource(fileName) + " [" + fileName + "]");

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -289,7 +289,7 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                     OWLOntology o = m.loadOntologyFromOntologyDocument(visalloBaseOntologySource, config);
                     loadedOntologies.add(o);
                 } catch (UnloadableImportException ex) {
-                    LOGGER.error("Could not load %s", ontologyFileIRI, ex);
+                    LOGGER.warn("Could not load existing %s", ontologyFileIRI, ex);
                 }
             }
         }

--- a/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/StructuredIngestWebAppPlugin.java
+++ b/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/StructuredIngestWebAppPlugin.java
@@ -108,10 +108,6 @@ public class StructuredIngestWebAppPlugin implements WebAppPlugin {
     }
 
     private void ensureOntologyDefined() {
-        if (ontologyRepository.isOntologyDefined(StructuredIngestOntology.IRI)) {
-            return;
-        }
-
         try (InputStream structuredFileOwl = StructuredIngestWebAppPlugin.class.getResourceAsStream("structured-file.owl")) {
             byte[] inFileData = IOUtils.toByteArray(structuredFileOwl);
             IRI tagIRI = IRI.create(StructuredIngestOntology.IRI);


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Now that ontologies files are MD5'ed and not loaded if the file hasn't changed
isOntologyDefined is no longer needed. Double loading the ontology will not
cause a reload unless the file's MD5 has changed.

CHANGELOG
Changed: Don't use isOntologyDefined to protect double loading ontologies
