### PR TITLE
Remove the requirement that webm encoding finish before showing video

### DIFF
--- a/web/war/src/main/webapp/js/detail/video/video.js
+++ b/web/war/src/main/webapp/js/detail/video/video.js
@@ -42,7 +42,8 @@ define([
         this.render = function() {
             var self = this;
 
-            if (!this.isVideoReady()) {
+            const formatsReady = this.isVideoReady();
+            if (!_.any(formatsReady)) {
                 this.videoRendered = false;
                 return this.$node.empty();
             }
@@ -55,6 +56,7 @@ define([
                 VideoScrubber.attachTo(this.select('previewSelector'), {
                     rawUrl: F.vertex.raw(this.model),
                     posterFrameUrl: F.vertex.image(this.model),
+                    formatsReady,
                     videoPreviewImageUrl: F.vertex.imageFrames(this.model),
                     duration: this.duration,
                     allowPlayback: true
@@ -93,12 +95,10 @@ define([
         };
 
         this.isVideoReady = function() {
-            return (
-                (F.vertex.props(this.model, 'http://visallo.org#video-webm') || [])
-                .concat(
-                    (F.vertex.props(this.model, 'http://visallo.org#video-mp4') || [])
-                )
-            ).length >= 2;
+            return _.object(['mp4', 'webm'], format => [
+                format,
+                F.vertex.props(this.model, `http://visallo.org#video-${format}`).length > 0
+            ]);
         };
 
         this.onPlayerTimeUpdate = function(evt, data) {

--- a/web/war/src/main/webapp/js/util/video/video.hbs
+++ b/web/war/src/main/webapp/js/util/video/video.hbs
@@ -1,4 +1,8 @@
 <video class="video-js vjs-default-skin" preload="none" poster="{{ posterFrameUrl }}">
+  {{#if formatsReady.mp4 }}
   <source src="{{ url }}&type=video/mp4" type="video/mp4">
+  {{/if}}
+  {{#if formatsReady.webm }}
   <source src="{{ url }}&type=video/webm" type="video/webm">
+  {{/if}}
 </video>


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions: Upload / Play videos

Points of Regression: None

CHANGELOG
Changed: Front-end will play videos if either h.264 or webm video properties exist. Previously would wait for both.
