### PR TITLE
Added: support for react components in advanced search

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -8,7 +8,8 @@ define([
     'util/popovers/withElementScrollingPositionUpdates',
     'configuration/plugins/registry',
     'd3',
-    './extensionToolbarPopover'
+    './extensionToolbarPopover',
+    'util/component/attacher'
 ], function(
     require,
     defineComponent,
@@ -19,7 +20,8 @@ define([
     withElementScrollingPositionUpdates,
     registry,
     d3,
-    SearchToolbarExtensionPopover) {
+    SearchToolbarExtensionPopover,
+    Attacher) {
     'use strict';
 
     var SEARCH_TYPES = ['Visallo'];
@@ -670,27 +672,37 @@ define([
                 $container.show();
 
                 if (attach) {
-                    require([path], function(AdvancedSearchExtension) {
-                        /**
-                         * Responsible for displaying the interface for
-                         * searching, and displaying the results.
-                         *
-                         * @typedef org.visallo.search.advanced~Component
-                         * @property {string} resultsSelector Css selector to
-                         * container that will hold results
-                         * @see module:components/List
-                         * @listens org.visallo.search.advanced#savedQuerySelected
-                         * @fires org.visallo.search.advanced#setCurrentSearchForSaving
-                         * @example <caption>Rendering results</caption>
-                         * List.attachTo($(this.attr.resultsSelector), {
-                         *     items: results
-                         * })
-                         */
-                        AdvancedSearchExtension.attachTo($container, {
-                            resultsSelector: '.search-pane .' + cls
+                    /**
+                     * Responsible for displaying the interface for
+                     * searching, and displaying the results.
+                     *
+                     * @typedef org.visallo.search.advanced~Component
+                     * @property {string} resultsSelector Css selector to
+                     * container that will hold results
+                     * @see module:components/List
+                     * @listens org.visallo.search.advanced#savedQuerySelected
+                     * @fires org.visallo.search.advanced#setCurrentSearchForSaving
+                     * @example <caption>Rendering results</caption>
+                     * List.attachTo($(this.attr.resultsSelector), {
+                     *     items: results
+                     * })
+                     */
+                    Attacher()
+                        .path(path)
+                        .node($container)
+                        .params({
+                            resultsSelector: '.search-pane .' + cls,
+                            resultsContainer: $('.search-pane .' + cls)
+                        })
+                        .behavior({
+                            setCurrentSearchForSaving: (evt, query) => {
+                                self.trigger($container, 'setCurrentSearchForSaving', query);
+                            }
+                        })
+                        .attach()
+                        .then(() => {
+                            self.trigger($container, 'searchtypeloaded', { type: newSearchType });
                         });
-                        self.trigger($container, 'searchtypeloaded', { type: newSearchType });
-                    })
                 } else {
                     self.trigger($container, 'searchtypeloaded', { type: newSearchType });
                 }

--- a/web/war/src/main/webapp/less/search/search.less
+++ b/web/war/src/main/webapp/less/search/search.less
@@ -138,11 +138,8 @@ width: 215px;
 }
 
 .advanced-search-type {
-  position: absolute;
-  top: 4.3em;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: relative;
+  flex: 1 1 auto;
   overflow: auto;
   overflow-x: hidden;
 }

--- a/web/war/src/main/webapp/less/visallo.less
+++ b/web/war/src/main/webapp/less/visallo.less
@@ -128,8 +128,15 @@ html.fullscreenDetails {
       }
     }
   }
-  .search-pane .content {
-    overflow: visible;
+  .search-pane {
+    .content {
+      overflow: visible;
+    }
+
+    > .content {
+      display: flex;
+      flex-direction: column
+    }
   }
 
   .search-pane,

--- a/web/web-base/src/main/java/org/visallo/web/JavascriptResourceHandler.java
+++ b/web/web-base/src/main/java/org/visallo/web/JavascriptResourceHandler.java
@@ -34,7 +34,8 @@ public class JavascriptResourceHandler implements RequestResponseHandler {
             EXECUTOR_CONCURRENT,
             EXECUTOR_IDLE_THREAD_RELEASE_SECONDS,
             TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>());
+            new LinkedBlockingQueue<>()
+    );
 
     static {
         compilationExecutor.allowCoreThreadTimeOut(true);
@@ -107,6 +108,9 @@ public class JavascriptResourceHandler implements RequestResponseHandler {
 
     private CachedCompilation compileIfNecessary(CachedCompilation previousCompilation) throws IOException {
         URL url = this.getClass().getResource(jsResourceName);
+        if (url == null) {
+            throw new VisalloException("Could not find resource: " + jsResourceName);
+        }
         long lastModified = url.openConnection().getLastModified();
 
         if (previousCompilation == null || previousCompilation.isNecessary(lastModified)) {
@@ -152,7 +156,8 @@ public class JavascriptResourceHandler implements RequestResponseHandler {
             externs.add(SourceFile.fromInputStream(
                     closureExternResourcePath,
                     this.getClass().getResourceAsStream(closureExternResourcePath),
-                    Charset.forName("UTF-8")));
+                    Charset.forName("UTF-8")
+            ));
         }
 
         Result result = compiler.compile(externs, inputs, compilerOptions);


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman sfeng88
- [ ] joeybrk372 rygim jharwig EvanOxfeld

CHANGELOG
Added: Support for react components in advanced search. `org.visallo.search.advanced` extension point now provides `renderResults`, `updateQueryStatus`, and `initialParameters`
Deprecated: `resultsSelector` parameter for the `org.visallo.search.advanced` extension point . Use `renderResults` instead.
