### PR TITLE
Log the load times of plugins if console available

### DIFF
--- a/web/war/src/main/webapp/js/visallo.js
+++ b/web/war/src/main/webapp/js/visallo.js
@@ -223,9 +223,13 @@ function(jQuery,
             } else {
                 updateVisalloLoadingProgress('extensions', 0);
                 var len = visalloPluginResources.afterAuth.length,
-                    i = 0;
+                    i = 0,
+                    pluginTimes = [];
                 Promise.all(visalloPluginResources.afterAuth.map(function(path) {
+                    const t0 = new Date().getTime();
                     return Promise.require(path).then(function() {
+                        const t1 = new Date().getTime();
+                        pluginTimes.push({ path, 'duration (ms)': t1 - t0 });
                         updateVisalloLoadingProgress('extensions', ++i / len);
                     })
                 }))
@@ -236,6 +240,16 @@ function(jQuery,
                     .then(function() {
                         updateVisalloLoadingProgress('userinterface');
                         loginSuccess({ user });
+                    })
+                    .finally(function() {
+                        if (window.console) {
+                            if ('groupCollapsed' in console && 'table' in console) {
+                                console.groupCollapsed('Plugin Load Metrics');
+                                console.log('Later plugins will be slower due to network concurrency limits')
+                                console.table(pluginTimes);
+                                console.groupEnd();
+                            }
+                        }
                     })
             }
         }


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman sfeng88
- [x] joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions: Look at console for "Plugin Load Times" table. Have to have browser that supports console.table and groupCollapsed

CHANGELOG
Added: Plugin load times are printed to console on Visallo load