### PR TITLE
Compile less and cache the result

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/LessResourceHandler.java
+++ b/web/web-base/src/main/java/org/visallo/web/LessResourceHandler.java
@@ -2,16 +2,18 @@ package org.visallo.web;
 
 import com.asual.lesscss.LessEngine;
 import com.asual.lesscss.LessOptions;
-import com.v5analytics.webster.Handler;
 import com.v5analytics.webster.HandlerChain;
 import com.v5analytics.webster.RequestResponseHandler;
 import org.apache.commons.io.IOUtils;
+import org.visallo.core.exception.VisalloException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 
@@ -19,25 +21,50 @@ public class LessResourceHandler implements RequestResponseHandler {
     private static LessEngine lessCompiler;
 
     private String lessResourceName;
+    private boolean checkLastModified;
+    private LessCache cache;
 
-    public LessResourceHandler(String lessResourceName) {
+    public LessResourceHandler(String lessResourceName, boolean checkLastModified) {
           this.lessResourceName = lessResourceName;
+          this.checkLastModified = checkLastModified;
     }
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, HandlerChain chain) throws Exception {
         response.setContentType("text/css");
 
+        synchronized (lessResourceName.intern()) {
+            if (cache == null) {
+                cache = new LessCache(getCompiled(), checkLastModified ? getLastModified() : 0l);
+            } else if (checkLastModified) {
+                long newLastModified = getLastModified();
+                if (cache.lastModified != newLastModified) {
+                    cache = new LessCache(getCompiled(), newLastModified);
+                }
+            }
+        }
+
+        try (PrintWriter outWriter = response.getWriter()) {
+            outWriter.println(cache.getOutput());
+        }
+    }
+
+    private String getCompiled() throws Exception {
         try (InputStream input = this.getClass().getResourceAsStream(lessResourceName)) {
             try (StringWriter writer = new StringWriter()) {
                 IOUtils.copy(input, writer, StandardCharsets.UTF_8);
                 String inputLess = writer.toString();
-                String output = lessCompiler().compile(inputLess);
-
-                try (PrintWriter outWriter = response.getWriter()) {
-                    outWriter.println(output);
-                }
+                return lessCompiler().compile(inputLess);
             }
+        }
+    }
+
+    private long getLastModified() {
+        URL url = this.getClass().getResource(lessResourceName);
+        try {
+            return url.openConnection().getLastModified();
+        } catch (IOException e) {
+            throw new VisalloException("Unable to find less resource: " + lessResourceName, e);
         }
     }
 
@@ -50,5 +77,23 @@ public class LessResourceHandler implements RequestResponseHandler {
             lessCompiler = new LessEngine(options);
         }
         return lessCompiler;
+    }
+
+    class LessCache {
+        private long lastModified;
+        private String output;
+
+        LessCache(String output, long lastModified) {
+            this.lastModified = lastModified;
+            this.output = output;
+        }
+
+        public long getLastModified() {
+            return lastModified;
+        }
+
+        public String getOutput() {
+            return output;
+        }
     }
 }

--- a/web/web-base/src/main/java/org/visallo/web/WebApp.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebApp.java
@@ -366,7 +366,7 @@ public class WebApp extends App {
     public void registerLess(final String lessResourceName) {
         String resourcePath = "css" + lessResourceName + ".css";
         if (isDevModeEnabled()) {
-            get("/" + resourcePath, new LessResourceHandler(lessResourceName));
+            get("/" + resourcePath, new LessResourceHandler(lessResourceName, isDevModeEnabled()));
             pluginsCssResources.add(resourcePath);
         } else {
             pluginsCssResourceHandler.appendLessResource(lessResourceName);


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman sfeng88
- [ ] joeybrk372 rygim jharwig EvanOxfeld

Improves performance of page load.

Testing Instructions: Plugin less files "Display as [name].less.css in network panel" should load correctly.

CHANGELOG
Changed: Plugin Less stylesheets are compiled once and cached. In `devMode=true` the last modified time is checked for recompilation