### PR TITLE
use generic error page for all errors to prevent sensitive information from being displayed to users (2.2.3)

### DIFF
--- a/web/war/src/main/webapp/WEB-INF/web.xml
+++ b/web/war/src/main/webapp/WEB-INF/web.xml
@@ -6,4 +6,28 @@
         <listener-class>org.visallo.web.ApplicationBootstrap</listener-class>
     </listener>
     <distributable/>
+    <error-page>
+        <error-code>401</error-code>
+        <location>/error.html</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/error.html</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/error.html</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/error.html</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/error.html</location>
+    </error-page>
+    <error-page>
+        <exception-type>java.lang.Exception</exception-type>
+        <location>/error.html</location>
+    </error-page>
 </web-app>

--- a/web/war/src/main/webapp/error.html
+++ b/web/war/src/main/webapp/error.html
@@ -1,0 +1,1 @@
+Unable to process request. Please contact your system administrator for more details.


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions: when there is an error in the developer network pane, make sure it shows a generic error page

Points of Regression:

CHANGELOG
Security: Added generic error page for all errors to prevent sensitive information from being displayed
