### PR TITLE
make smtp email log message displaying the subject and who the email is from print at info level (2.2.3)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/email/SmtpEmailRepository.java
+++ b/core/core/src/main/java/org/visallo/core/email/SmtpEmailRepository.java
@@ -38,7 +38,7 @@ public class SmtpEmailRepository implements EmailRepository {
     @Override
     public void send(String fromAddress, String[] toAddresses, String subject, String body) {
         String joinedToAddresses = Joiner.on(",").join(toAddresses);
-        LOGGER.debug("sending SMTP email from: \"%s\", to: \"%s\", subject: \"%s\"", fromAddress, joinedToAddresses, subject);
+        LOGGER.info("sending SMTP email from: \"%s\", to: \"%s\", subject: \"%s\"", fromAddress, joinedToAddresses, subject);
         LOGGER.debug("sending SMTP email body:%n%s", body);
 
         try {


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 rygim jharwig EvanOxfeld

CHANGELOG
Changed: log level for smtp email to display subject and sender to INFO level