### PR TITLE
Changed: Replace breadthfirst graph layout with dagre

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -2,6 +2,8 @@ define([
     'react',
     'underscore',
     'cytoscape',
+    'cytoscape-dagre',
+    'dagre',
     'fast-json-patch',
     'components/NavigationControls',
     'colorjs',
@@ -13,6 +15,8 @@ define([
     React,
     _,
     cytoscape,
+    cytoscapeDagre,
+    dagre,
     jsonpatch,
     NavigationControls,
     colorjs,
@@ -40,16 +44,8 @@ define([
             },
             edgeElasticity: 10
         },
-        breadthfirst: {
-            roots: function(nodes, options) {
-                if (options && options.onlySelected) {
-                    return [];
-                }
-                return nodes.roots().map(function(n) { return n.id(); })
-            },
-            directed: false,
-            circle: false,
-            maximalAdjustments: 10
+        dagre: {
+
         }
     };
     const PREVIEW_DEBOUNCE_SECONDS = 3;
@@ -129,6 +125,7 @@ define([
             const updateControlDragSelection = (nodeId = null) => this.setState({ controlDragSelection: nodeId });
             fixCytoscapeCorsHandling(cy);
             cytoscape('layout', 'bettergrid', betterGrid);
+            cytoscapeDagre(cytoscape, dagre);
 
             this.clientRect = this.refs.cytoscape.getBoundingClientRect();
             this.setState({ cy })

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Menu.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Menu.jsx
@@ -79,7 +79,7 @@ define([
                     <ul className="dropdown-menu">
                         <li><a onMouseUp={this.props.onEvent} data-func="Layout" data-args='["circle", {}]' tabIndex="-1" href="#">{i18n('graph.contextmenu.layout.circle')}</a></li>
                         <li><a onMouseUp={this.props.onEvent} data-func="Layout" data-args='["bettergrid", {}]' tabIndex="-1" href="#">{i18n('graph.contextmenu.layout.grid')}</a></li>
-                        <li><a onMouseUp={this.props.onEvent} data-func="Layout" data-args='["breadthfirst", {}]' tabIndex="-1" href="#">{i18n('graph.contextmenu.layout.hierarchical')}</a></li>
+                        <li><a onMouseUp={this.props.onEvent} data-func="Layout" data-args='["dagre", {}]' tabIndex="-1" href="#">{i18n('graph.contextmenu.layout.hierarchical')}</a></li>
                         <li><a onMouseUp={this.props.onEvent} data-func="Layout" data-args='["cose", {}]' tabIndex="-1" href="#">{i18n('graph.contextmenu.layout.force_directed')}</a></li>
                         {this.renderLayoutExtensions(false)}
                     </ul>

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "cytoscape": "2.7.14"
+    "cytoscape": "2.7.14",
+    "cytoscape-dagre": "^1.6.0"
   },
   "scripts": {
     "test": "node ./node_modules/jest/bin/jest.js"

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
@@ -957,9 +957,22 @@ cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+cytoscape-dagre@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-dagre/-/cytoscape-dagre-1.6.0.tgz#10abcc30ef348b60132cad64820b66ddc7fcd069"
+  dependencies:
+    dagre "~0.7.4"
+
 cytoscape@2.7.14:
   version "2.7.14"
   resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-2.7.14.tgz#a7795db9d507465bee0c7f42b0a05724847aa9bf"
+
+dagre@~0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.7.4.tgz#de72f0e74a550ce11ce638f0a136fed712398022"
+  dependencies:
+    graphlib "^1.0.5"
+    lodash "^3.10.0"
 
 dashdash@^1.12.0:
   version "1.14.0"
@@ -1312,6 +1325,12 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+graphlib@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-1.0.7.tgz#0cab2df0ffe6abe070b2625bfa1edb6ec967b8b1"
+  dependencies:
+    lodash "^3.10.0"
 
 growly@^1.2.0:
   version "1.3.0"
@@ -2015,6 +2034,10 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash@^3.10.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"

--- a/web/war/src/main/webapp/js/visallo.js
+++ b/web/war/src/main/webapp/js/visallo.js
@@ -28,6 +28,8 @@ function(jQuery,
 
     $.ui = { keyCode: { ENTER: 13 } };
 
+    lockDownUnderscore(_);
+
     // Debug retina/non-retina by changing to 1/2
     // window.devicePixelRatio = 1;
 
@@ -433,4 +435,12 @@ function(jQuery,
         return (/#\s*$/).test(url) || url.indexOf('#') === -1;
     }
 
+    // Both lodash and underscore pollute the global 'window' object with '_', this prevents future includes of these
+    // libraries from doing that.
+    function lockDownUnderscore(_) {
+        Object.defineProperty(window, '_', {
+            value: _,
+            writeable: false
+        });
+    }
 });


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 rygim jharwig EvanOxfeld

Many times breadthfirst will create a single long line of entities on the graph when laying out nodes. 
Dagre is much better at spacing the nodes out horizontally as well.

Testing Instructions:
Add nodes with high linking to the graph. Right click and layout hierarchical. The nodes should layout better than before. 

CHANGELOG
Changed: Replace breadthfirst graph layout with dagre
