### PR TITLE
Fix OntologyRepositoryTestBase for OWL files in Jars

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryTestBase.java
@@ -269,7 +269,6 @@ public abstract class OntologyRepositoryTestBase extends VisalloInMemoryTestBase
         } else {
              testOwl = new File(owlUri);
         }
-        System.out.println(testOwl);
         getOntologyRepository().importFile(testOwl, IRI.create(iri), authorizations);
     }
 


### PR DESCRIPTION
For certain invocations of mvn, when the test was trying to load the OWL files from the classpath they were getting a URI to the file within the compiled jar in the m2 repository. Passing this URI to the File constructor was failing the tests. This change will check to see if the URI is in a jar or on the filesystem. If in a jar, it will first extract to the filesystem before continuing to import the OWL file. 

- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 rygim jharwig EvanOxfeld

Testing Instructions:
Ensure the ontology unit tests pass.

