### PR TITLE
Fixed VertexiumOntologyRepository losing possible values

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryTestBase.java
@@ -134,6 +134,13 @@ public abstract class OntologyRepositoryTestBase extends VisalloInMemoryTestBase
         assertEquals("First Met", firstMetProperty.getDisplayName());
         assertEquals(PropertyType.DATE, firstMetProperty.getDataType());
 
+        OntologyProperty favColorProperty = getOntologyRepository().getPropertyByIRI(TEST_IRI + "#favoriteColor");
+        assertEquals("Favorite Color", favColorProperty.getDisplayName());
+        possibleValues = favColorProperty.getPossibleValues();
+        assertEquals(2, possibleValues.size());
+        assertEquals("red 1", possibleValues.get("Red"));
+        assertEquals("blue 2", possibleValues.get("Blue"));
+
         Relationship relationship = getOntologyRepository().getRelationshipByIRI(TEST_IRI + "#personKnowsPerson");
         assertTrue(relationship.getProperties()
                 .stream()
@@ -233,6 +240,13 @@ public abstract class OntologyRepositoryTestBase extends VisalloInMemoryTestBase
         OntologyProperty firstMetProperty = getOntologyRepository().getPropertyByIRI(TEST_IRI + "#firstMet");
         assertEquals("First Met", firstMetProperty.getDisplayName());
         assertEquals(PropertyType.DATE, firstMetProperty.getDataType());
+
+        OntologyProperty favColorProperty = getOntologyRepository().getPropertyByIRI(TEST_IRI + "#favoriteColor");
+        assertEquals("Favorite Color", favColorProperty.getDisplayName());
+        possibleValues = favColorProperty.getPossibleValues();
+        assertEquals(2, possibleValues.size());
+        assertEquals("red 1", possibleValues.get("Red"));
+        assertEquals("blue 2", possibleValues.get("Blue"));
 
         Relationship relationship = getOntologyRepository().getRelationshipByIRI(TEST_IRI + "#personKnowsPerson");
         assertTrue(relationship.getProperties()

--- a/core/core-test/src/main/resources/org/visallo/core/model/ontology/test.owl
+++ b/core/core-test/src/main/resources/org/visallo/core/model/ontology/test.owl
@@ -107,6 +107,22 @@
         <rdfs:range rdf:resource="&xsd;dateTime"/>
     </owl:DatatypeProperty>
 
+
+    <!-- http://visallo.org/test#favoriteColor -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/test#favoriteColor">
+        <rdfs:label xml:lang="en">Favorite Color</rdfs:label>
+        <visallo:textIndexHints>EXACT_MATCH</visallo:textIndexHints>
+        <rdfs:domain rdf:resource="http://visallo.org/test#person"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+        <visallo:possibleValues xml:lang="en">
+        {
+            &quot;Red&quot;: &quot;red 1&quot;,
+            &quot;Blue&quot;: &quot;blue 2&quot;
+        }
+        </visallo:possibleValues>
+    </owl:DatatypeProperty>
+
     <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //

--- a/core/core-test/src/main/resources/org/visallo/core/model/ontology/test_changed.owl
+++ b/core/core-test/src/main/resources/org/visallo/core/model/ontology/test_changed.owl
@@ -59,6 +59,22 @@
         <visallo:updateable rdf:datatype="&xsd;boolean">true</visallo:updateable>
         <visallo:deleteable rdf:datatype="&xsd;boolean">true</visallo:deleteable>
     </owl:DatatypeProperty>
+
+
+    <!-- http://visallo.org/test#favoriteColor -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org/test#favoriteColor">
+        <rdfs:label xml:lang="en">Favorite Color</rdfs:label>
+        <visallo:textIndexHints>EXACT_MATCH</visallo:textIndexHints>
+        <rdfs:domain rdf:resource="http://visallo.org/test#person"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+        <visallo:possibleValues xml:lang="en">
+        {
+            &quot;Red&quot;: &quot;red 1&quot;,
+            &quot;Blue&quot;: &quot;blue 2&quot;
+        }
+        </visallo:possibleValues>
+    </owl:DatatypeProperty>
 </rdf:RDF>
 
 

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -667,6 +667,9 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                 if (dependentPropertyIris != null) {
                     saveDependentProperties(vertexId, dependentPropertyIris);
                 }
+                if (possibleValues != null) {
+                    OntologyProperties.POSSIBLE_VALUES.updateProperty(elemCtx, JSONUtil.toJson(possibleValues), VISIBILITY.getVisibility());
+                }
                 if (intents != null) {
                     Metadata metadata = new Metadata();
                     for (String intent : intents) {


### PR DESCRIPTION
Fixed a bug in the VertexiumOntologyRepository where the possible values for a property were lost if the OWL file was re-imported.

- [x] joeferner
- [ ] sfeng88
- [x] mwizeman joeybrk372 rygim jharwig

Testing Instructions:
1.) Create an OWL file with a property that has possible values
2.) Import that OWL file into Visallo
3.) Update something in the same OWL file
4.) Re-import the OWL file
5.) Ensure that the property still has possible values set

CHANGELOG
Fixed: VertexiumOntologyRepository was losing possible values for a property if the OWL file was re-imported
