### PR TITLE
Changed: disable select all in search results if all elements not loaded

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -648,6 +648,8 @@ search.help.scope=Search
 search.help.toggle=Show search pane
 search.query.invalid=Invalid Query
 
+search.noSelectAllWhileLoading=Select all is not available while results are loading
+
 properties.groups.count.hover.property=property
 properties.groups.count.hover.property.plural=properties
 properties.groups.count.hover.value=value

--- a/web/war/src/main/webapp/js/util/element/list.js
+++ b/web/war/src/main/webapp/js/util/element/list.js
@@ -129,10 +129,7 @@ define([
                     self.$node
                         .addClass('element-list')
                         .html(template({
-                            scrolling: self.localScrolling || (
-                                self.attr.infiniteScrolling &&
-                                self.attr.total !== self.attr.items.length
-                            )
+                            scrolling: self.isScrolling()
                         }));
 
                     self.attachEvents();
@@ -167,6 +164,13 @@ define([
                     self.trigger('listRendered');
             });
         });
+
+        this.isScrolling = function() {
+            return this.localScrolling || (
+                    this.attr.infiniteScrolling &&
+                    this.attr.total !== this.attr.items.length
+                );
+        };
 
         this.onClick = function(event) {
             event.preventDefault();
@@ -275,6 +279,14 @@ define([
 
         this.onSelectAll = function(e) {
             e.stopPropagation();
+
+            // Don't allow select all if all items are not loaded, it is misleading
+            if (this.isScrolling()) {
+                this.trigger('displayInformation', {
+                    message: i18n('search.noSelectAllWhileLoading')
+                });
+                return;
+            }
 
             var items = this.select('itemSelector').addClass('active');
             this.selectItems(items);


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Being able to select all elements before they are all loaded in the search
results panel is misleading. This commit adds a message indicating that
all results are not loaded yet

see https://github.com/visallo/visallo-lts/issues/1799

CHANGELOG
Changed: disable select all in search results if all elements not loaded
