### PR TITLE
Default the search status to success when missing

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -473,7 +473,7 @@ define([
                 )
             }
 
-            this.savedQueries[searchType].status = status || {};
+            this.savedQueries[searchType].status = status || { success: true };
             this.updateTypeCss();
         };
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

When a long running search is opened the first time status is not defined
but if you open another long running search the second time around the search
status is empty resulting in an error being displayed. This commit defaults
missing status to success.

CHANGELOG
Fixed: Default LRP search status to "success" if the status is missing

