### PR TITLE
FF: fix select dropdown closing immediately

### DIFF
--- a/web/war/src/main/webapp/js/util/clipboardManager.js
+++ b/web/war/src/main/webapp/js/util/clipboardManager.js
@@ -129,7 +129,7 @@ define([
         };
 
         this._onClick = function(event) {
-            if ($(event.target).is('input,select,textarea,.visallo-allow-focus,.visallo-allow-focus *')) return;
+            if ($(event.target).is('input,select,option,textarea,.visallo-allow-focus,.visallo-allow-focus *')) return;
 
             var inFocus = $(':focus');
             // Check for previous focus, since we are going to steal it to


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

This is because Firefox triggers pointer events on option elements.

Testing Instructions: 
1. Click timezone select to open dropdown
1. Scroll down while over dropdown
1. Click on an option
1. Click the select again to open the dropdown

CHANGELOG
Fixed: In Firefox, select drop-downs would start closing immediately if you had scrolled and selected an option previously.
