### PR TITLE
Added: method to graph plugins to support clearing the graph style cache

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -86,6 +86,7 @@ define([
             hasPreview: PropTypes.bool,
             editable: PropTypes.bool,
             onCollapseSelectedNodes: PropTypes.func.isRequired,
+            reapplyGraphStylesheet: PropTypes.func.isRequired,
             ...eventPropTypes
         },
 
@@ -860,7 +861,10 @@ define([
             if (cy) {
                 return this.props.tools.map(tool => ({
                     ...tool,
-                    props: { cy }
+                    props: {
+                        cy,
+                        reapplyGraphStylesheet: this.props.reapplyGraphStylesheet
+                    }
                 }))
             }
             return [];

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -295,6 +295,7 @@ define([
                         onGhostFinished={this.props.onGhostFinished}
                         onUpdatePreview={this.onUpdatePreview}
                         editable={editable}
+                        reapplyGraphStylesheet={this.reapplyGraphStylesheet}
                     ></Cytoscape>
 
                     {cyElements.nodes.length === 0 ? (
@@ -338,6 +339,7 @@ define([
         },
 
         reapplyGraphStylesheet() {
+            memoizeClear();
             this.forceUpdate();
         },
 


### PR DESCRIPTION
- [x] joeferner
- [ ] sfeng88
- [ ] mwizeman joeybrk372 jharwig

This allows graph plugins which rely on the style cache to clear the cache if any changes are made that are not picked up by the redux state change such as user preference changes

CHANGELOG
Added: method to graph plugins to support clearing the graph style cache
