### PR TITLE
Fix found paths through collapsed nodes

### DIFF
--- a/web/war/src/main/webapp/js/activity/builtin/findPath.js
+++ b/web/war/src/main/webapp/js/activity/builtin/findPath.js
@@ -97,7 +97,8 @@ define([
                         vertices = _.chain(paths).flatten().uniq().value();
 
                     self.trigger('focusPaths', {
-                        paths: paths,
+                        paths,
+                        labels: process.labels,
                         sourceId: self.attr.process.outVertexId,
                         targetId: self.attr.process.inVertexId,
                         processId: self.attr.process.id


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

CHANGELOG
Fixed: When highlighting found paths on a graph, relationships that were excluded from the search are no longer highlighted.
