### PR TITLE
Don't override async load of worker scripts in development

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/data-worker.js
+++ b/web/war/src/main/webapp/js/data/web-worker/data-worker.js
@@ -163,7 +163,10 @@ function setupRequireJs(data, callback) {
     require.deps = data.webWorkerResources;
     require.callback = callback;
     importScripts(BASE_URL + '/libs/requirejs/require.js?' + data.cacheBreaker);
-    require.load = asyncRequireJSLoader
+
+    if (visalloEnvironment.prod) {
+        require.load = asyncRequireJSLoader
+    }
 }
 
 function onMessageHandler(event) {


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

The way we make importScripts async by wrapping it in and then importing a blob URL does not allow dev tools to pick up the sources. Worker scripts would still stop if you put debugger statements, but browsing and setting breakpoints in dev tools is much easier.

no CHANGELOG
