### PR TITLE
Fix graph connection popover anchoring to other vertices

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -642,7 +642,7 @@ define([
             }
             if (draw) {
                 const upElement = cy.renderer().findNearestElement(x, y, true, false);
-                if (!upElement || draw.vertexId === upElement.id()) {
+                if (!upElement || draw.vertexId === upElement.id() || draw.toVertexId) {
                     this.cancelDraw();
                     if (ctrlKey && upElement) {
                         this.onContextTap(event);


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions: Start creating an edge between two vertices on the graph. Click or cmd+click on a third vertex. The popover should close and you should not be creating an edge anymore.

CHANGELOG
Fixed: When trying to find a path or connecting two entities on the graph, if you clicked on a third entity the form would move to that entity until you closed it by clicking somewhere else.
