### PR TITLE
Fix an Error Resolving Multiple Relationships from the Same Source Text - 3.1

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionRepository.java
@@ -460,6 +460,42 @@ public class TermMentionRepository {
             Visibility visibility,
             Authorizations authorizations
     ) {
+        addSourceInfoToVertex(
+            vertex,
+            forElementId,
+            forType,
+            propertyKey,
+            propertyName,
+            propertyVisibility,
+            null,
+            snippet,
+            textPropertyKey,
+            textPropertyName,
+            startOffset,
+            endOffset,
+            outVertex,
+            visibility,
+            authorizations
+        );
+    }
+
+    public void addSourceInfoToVertex(
+            Vertex vertex,
+            String forElementId,
+            TermMentionFor forType,
+            String propertyKey,
+            String propertyName,
+            Visibility propertyVisibility,
+            String edgeId,
+            String snippet,
+            String textPropertyKey,
+            String textPropertyName,
+            long startOffset,
+            long endOffset,
+            Vertex outVertex,
+            Visibility visibility,
+            Authorizations authorizations
+    ) {
         visibility = VisalloVisibility.and(visibility, VISIBILITY_STRING);
         String termMentionVertexId = vertex.getId() + "hasSource" + outVertex.getId();
         if (propertyKey != null) {
@@ -470,6 +506,9 @@ public class TermMentionRepository {
         }
         if (propertyVisibility != null) {
             termMentionVertexId += ":" + propertyVisibility;
+        }
+        if (edgeId != null) {
+            termMentionVertexId += ":" + edgeId;
         }
         VertexBuilder m = graph.prepareVertex(termMentionVertexId, visibility);
         VisalloProperties.TERM_MENTION_FOR_ELEMENT_ID.setProperty(m, forElementId, visibility);
@@ -544,6 +583,7 @@ public class TermMentionRepository {
                 propertyKey,
                 propertyName,
                 propertyVisibility,
+                edge.getId(),
                 snippet,
                 textPropertyKey,
                 textPropertyName,
@@ -560,6 +600,7 @@ public class TermMentionRepository {
                 propertyKey,
                 propertyName,
                 propertyVisibility,
+                edge.getId(),
                 snippet,
                 textPropertyKey,
                 textPropertyName,
@@ -651,7 +692,9 @@ public class TermMentionRepository {
         Authorizations authorizationsWithTermMentions = getAuthorizations(authorizations);
         Vertex vertex = graph.getVertex(vertexId, authorizationsWithTermMentions);
 
-        if (vertex == null) { return null; }
+        if (vertex == null) {
+            return null;
+        }
 
         Iterable<Vertex> termMentions = vertex.getVertices(
                 Direction.IN,


### PR DESCRIPTION
Fix an error that may occur when multiple relationships are created for a vertex at different visibilities and sourced from the same text.

- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions:
1. Import a document into a graph
2. Select the new document vertex
3. Highlight and resolve a new entity in the "Text" field
4. Highlight and resolve a another new entity in the "Text" field
5. Copy a string from elsewhere in the "Text" field
6. Drag the first entity onto the second entity
7. Choose a relationship type, paste the copied text into the "Justification" field, and press "Connect"
8. Publish all changes
9. Resolve a third entity
10. Copy a another string from elsewhere in the "Text" field
11. Drag the first entity onto the third entity
12. Choose a relationship type, paste the copied text into the "Justification" field, and press "Connect"
13. Deselect the document vertex
14. Reselect the document vertex
15. Ensure the text and all entities appear as expected. Ensure no errors are reported.

CHANGELOG
Fixed: Fix an error that may occur when multiple relationships are created for a vertex at different visibilities and sourced from the same text.
