### PR TITLE
Fix admin tool background becoming transparent

### DIFF
--- a/web/war/src/main/webapp/less/visallo.less
+++ b/web/war/src/main/webapp/less/visallo.less
@@ -128,6 +128,19 @@ html.fullscreenDetails {
       }
     }
   }
+  .admin-pane {
+    > .content {
+      overflow-y: hidden;
+
+      > .admin-list.nav-list {
+        .box-sizing(border-box);
+        height: 100%;
+        overflow-y: auto;
+        margin: 0;
+        padding-top: 0.5em;
+      }
+    }
+  }
   .search-pane {
     .content {
       overflow: visible;


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions: 
1. Open the admin pane
1. Select a tool.
1. Scroll the tool list to the bottom.
1. Select a tool.

CHANGELOG
Fixed: In Chrome, the background of an admin tool would become partially invisible if you had already scrolled down the list of tools available before selecting it.
