### PR TITLE
Document that we require a 64-bit architecture to run Visallo

### DIFF
--- a/docs/getting-started/dependencies.md
+++ b/docs/getting-started/dependencies.md
@@ -1,6 +1,6 @@
 # Dependencies
 
-Setting up a Visallo development environment is very similar across Mac OS X, Windows, and Linux platforms and requires only a few dependencies to get started. The only required dependencies to get started are a [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [Git](http://git-scm.com/), and [Maven 3.3.9 or higher](https://maven.apache.org). Please see the documentation for each respective project for installation instructions.
+Setting up a Visallo development environment is very similar across Mac OS X, Windows, and Linux platforms and requires only a few dependencies to get started. The only required dependencies to get started are a 64-bit operating system, [64-bit Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [Git](http://git-scm.com/), and [Maven 3.3.9 or higher](https://maven.apache.org). Please see the documentation for each respective project for installation instructions.
 
 ## Browser Support
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

On some 32-bit architectures, the default Visallo settings ([such are those for surefire here](https://github.com/visallo/visallo/blob/master/root/pom.xml#L799)) don't work. This updates the documentation to list a 64-bit architecture as one of our dependencies.

CHANGELOG
Documentation: Updated the documentation to list a 64-bit architecture as a dependency.
