### PR TITLE
Add missing name and description annotations to web plugins

### DIFF
--- a/web/plugins/ingest-cloud-s3/src/main/java/org/visallo/web/ingest/cloud/s3/AmazonS3WebAppPlugin.java
+++ b/web/plugins/ingest-cloud-s3/src/main/java/org/visallo/web/ingest/cloud/s3/AmazonS3WebAppPlugin.java
@@ -1,6 +1,8 @@
 package org.visallo.web.ingest.cloud.s3;
 
 import com.v5analytics.webster.Handler;
+import org.visallo.core.model.Description;
+import org.visallo.core.model.Name;
 import org.visallo.web.VisalloCsrfHandler;
 import org.visallo.web.WebApp;
 import org.visallo.web.WebAppPlugin;
@@ -9,6 +11,8 @@ import org.visallo.web.privilegeFilters.ReadPrivilegeFilter;
 
 import javax.servlet.ServletContext;
 
+@Name("Amazon S3 Cloud Ingest")
+@Description("Adds support for importing structured data from Amazon S3 buckets")
 public class AmazonS3WebAppPlugin implements WebAppPlugin {
 
     @Override

--- a/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/StructuredIngestWebAppPlugin.java
+++ b/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/StructuredIngestWebAppPlugin.java
@@ -24,7 +24,7 @@ import javax.servlet.ServletContext;
 import java.io.InputStream;
 
 @Name("Structured File")
-@Description("Supports importing structured data from CSV and Excel")
+@Description("Supports importing structured data")
 public class StructuredIngestWebAppPlugin implements WebAppPlugin {
     private final OntologyRepository ontologyRepository;
     private final UserRepository userRepository;

--- a/web/plugins/structured-ingest/parquet/src/main/java/org/visallo/web/structuredingest/parquet/ParquetWebAppPlugin.java
+++ b/web/plugins/structured-ingest/parquet/src/main/java/org/visallo/web/structuredingest/parquet/ParquetWebAppPlugin.java
@@ -1,11 +1,15 @@
 package org.visallo.web.structuredingest.parquet;
 
 import com.v5analytics.webster.Handler;
+import org.visallo.core.model.Description;
+import org.visallo.core.model.Name;
 import org.visallo.web.WebApp;
 import org.visallo.web.WebAppPlugin;
 
 import javax.servlet.ServletContext;
 
+@Name("Structured File Parquet support")
+@Description("Adds support for importing structured data from Parquet files")
 public class ParquetWebAppPlugin implements WebAppPlugin {
     @Override
     public void init(WebApp app, ServletContext servletContext, Handler authenticationHandler) {

--- a/web/plugins/structured-ingest/spreadsheet/src/main/java/org/visallo/web/structuredingest/spreadsheet/SpreadsheetWebAppPlugin.java
+++ b/web/plugins/structured-ingest/spreadsheet/src/main/java/org/visallo/web/structuredingest/spreadsheet/SpreadsheetWebAppPlugin.java
@@ -1,11 +1,15 @@
 package org.visallo.web.structuredingest.spreadsheet;
 
 import com.v5analytics.webster.Handler;
+import org.visallo.core.model.Description;
+import org.visallo.core.model.Name;
 import org.visallo.web.WebApp;
 import org.visallo.web.WebAppPlugin;
 
 import javax.servlet.ServletContext;
 
+@Name("Structured File CSV and Excel support")
+@Description("Adds support for importing structured data from CSV and Excel files")
 public class SpreadsheetWebAppPlugin implements WebAppPlugin {
     @Override
     public void init(WebApp app, ServletContext servletContext, Handler authenticationHandler) {


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions:
1. Log into Visallo as an administrator
2. Open the Admin Plugin List from the toolbar
3. Expand Web App Plugins
4. Verify that they all have names and descriptions

CHANGELOG
Added: Name and description annotations to web plugins that were missing them
