### PR TITLE
Cleanup User currentWorkspace settings on Case Deletion

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUserRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUserRepository.java
@@ -265,12 +265,16 @@ public class VertexiumUserRepository extends UserRepository {
         User user = findById(userId);
         checkNotNull(user, "Could not find user: " + userId);
         Vertex userVertex = findByIdUserVertex(user.getUserId());
-        UserVisalloProperties.CURRENT_WORKSPACE.setProperty(
-                userVertex,
-                workspaceId,
-                VISIBILITY.getVisibility(),
-                authorizations
-        );
+        if (workspaceId == null) {
+            UserVisalloProperties.CURRENT_WORKSPACE.removeProperty(userVertex, authorizations);
+        } else {
+            UserVisalloProperties.CURRENT_WORKSPACE.setProperty(
+                    userVertex,
+                    workspaceId,
+                    VISIBILITY.getVisibility(),
+                    authorizations
+            );
+        }
         graph.flush();
         return user;
     }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -163,7 +163,15 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
             ).forEach(productId -> deleteProduct(workspaceVertex.getId(), productId, user));
 
             getGraph().softDeleteVertex(workspaceVertex, authorizations);
+
+            List<WorkspaceUser> usersWithAccess = findUsersWithAccess(workspace.getWorkspaceId(), user);
+            usersWithAccess.forEach(userWithAccess -> {
+                if (workspace.getWorkspaceId().equals(userRepository.getCurrentWorkspaceId(userWithAccess.getUserId()))) {
+                    userRepository.setCurrentWorkspace(userWithAccess.getUserId(), null);
+                }
+            });
             getGraph().flush();
+            clearCache();
 
             graphAuthorizationRepository.removeAuthorizationFromGraph(workspace.getWorkspaceId());
         });

--- a/web/web-base/src/main/java/org/visallo/web/routes/user/MeGet.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/user/MeGet.java
@@ -1,11 +1,9 @@
 package org.visallo.web.routes.user;
 
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.handlers.CSRFHandler;
-import org.vertexium.util.IterableUtils;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workspace.Workspace;
 import org.visallo.core.model.workspace.WorkspaceRepository;
@@ -15,7 +13,6 @@ import org.visallo.core.util.VisalloLoggerFactory;
 import org.visallo.web.clientapi.model.ClientApiUser;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +71,7 @@ public class MeGet implements ParameterizedHandler {
                 workspace = workspaceRepository.add(user);
             }
 
+            userRepository.setCurrentWorkspace(user.getUserId(), workspace.getWorkspaceId());
             userMe.setCurrentWorkspaceId(workspace.getWorkspaceId());
             userMe.setCurrentWorkspaceName(workspace.getDisplayTitle());
         }

--- a/web/web-base/src/main/java/org/visallo/web/routes/workspace/WorkspaceCreate.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/workspace/WorkspaceCreate.java
@@ -5,6 +5,7 @@ import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Optional;
 import org.vertexium.Authorizations;
+import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.model.workspace.Workspace;
 import org.visallo.core.model.workspace.WorkspaceRepository;
@@ -18,27 +19,30 @@ public class WorkspaceCreate implements ParameterizedHandler {
 
     private final WorkspaceRepository workspaceRepository;
     private final WorkQueueRepository workQueueRepository;
+    private final AuthorizationRepository authorizationRepository;
 
     @Inject
     public WorkspaceCreate(
             final WorkspaceRepository workspaceRepository,
-            final WorkQueueRepository workQueueRepository
+            final WorkQueueRepository workQueueRepository,
+            AuthorizationRepository authorizationRepository
     ) {
         this.workspaceRepository = workspaceRepository;
         this.workQueueRepository = workQueueRepository;
+        this.authorizationRepository = authorizationRepository;
     }
 
     @Handle
     public ClientApiWorkspace handle(
             @Optional(name = "title") String title,
-            User user,
-            Authorizations authorizations
+            User user
     ) throws Exception {
         Workspace workspace;
 
         workspace = workspaceRepository.add(title, user);
 
         LOGGER.info("Created workspace: %s, title: %s", workspace.getWorkspaceId(), workspace.getDisplayTitle());
+        Authorizations authorizations = authorizationRepository.getGraphAuthorizations(user);
         ClientApiWorkspace clientApiWorkspace = workspaceRepository.toClientApi(workspace, user, authorizations);
 
         workQueueRepository.pushWorkspaceChange(clientApiWorkspace, clientApiWorkspace.getUsers(), user.getUserId(), null);


### PR DESCRIPTION
Fix multiple issues related to users having a CURRENT_WORKSPACE that is deleted:

1. Update the workspace repository code to unset the CURRENT_WORKSPACE property for any user that has their current workspace deleted.
2. Update the MeGet route so that if it has to create a new workspace for a user it sets it as the CURRENT_WORKSPACE
3. Update the WorkspaceCreate route to not include the CURRENT_WORKSPACE as an authorization (happened automatically when declaring auths as a parameter). This was a problem in the event a user had just deleted their only case. The front end will send a request to create a new case with the id of the old one as a header.

- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions:
1. Create and delete cases and ensure that the user interface does not encounter any problems
2. Share cases with between users and delete them both while a user is online an offline

CHANGELOG
Fixed: Occasional issue related to users having a current workspace preference saved that is but that workspace is deleted.
