### PR TITLE
Ensure that built in properties are being set properly

### DIFF
--- a/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
+++ b/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
@@ -292,25 +292,25 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
      * deltas between the historical values.
      */
     public static ClientApiHistoricalPropertyResults calculateHistoricalPropertyDeltas(
-        Iterable<HistoricalPropertyValue> historicalPropertyValues, Locale locale, ResourceBundle resourceBundle,
-            boolean withVisibility) {
-       
+            Iterable<HistoricalPropertyValue> historicalPropertyValues, Locale locale, ResourceBundle resourceBundle,
+            boolean withVisibility
+    ) {
         ClientApiHistoricalPropertyResults result = new ClientApiHistoricalPropertyResults();
-        
+
         // Sort chronologically
         List<HistoricalPropertyValue> sortedHistoricalValues = Lists.newArrayList(historicalPropertyValues);
-        Collections.sort(sortedHistoricalValues, Collections.reverseOrder());
+        sortedHistoricalValues.sort(Collections.reverseOrder());
 
         Map<String, HistoricalPropertyValue> cachedValues = new HashMap<>();
-        ClientApiHistoricalPropertyResults.Event event = null;
-        HistoricalPropertyValue conceptTypeHpv = null;
+        ClientApiHistoricalPropertyResults.Event event;
+        HistoricalPropertyValue conceptTypeHpv;
 
         int i = 0;
         for (HistoricalPropertyValue hpv : sortedHistoricalValues) {
             String key = hpv.getPropertyKey() + hpv.getPropertyName();
             HistoricalPropertyValue cached = cachedValues.get(key);
             event = null;
-            
+
             if (cached == null) { // Add
                 if (hpv.getPropertyName().equals(VisalloProperties.CONCEPT_TYPE.getPropertyName())) {
                     conceptTypeHpv = hpv;
@@ -330,8 +330,7 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
                     if (modifiedByHpv != null) {
                         // Use the ModifiedBy property to complete the ConceptType event
                         ClientApiHistoricalPropertyResults.Event modifiedByEvent = generatePropertyAddedEvent(modifiedByHpv, locale, resourceBundle, withVisibility);
-                        String modifiedBy = modifiedByEvent.fields.get("value");
-                        event.modifiedBy = modifiedBy;
+                        event.modifiedBy = modifiedByEvent.fields.get("value");
                     }
                 } else {
                     event = generatePropertyAddedEvent(hpv, locale, resourceBundle, withVisibility);
@@ -347,22 +346,22 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
                 if (hasHistoricalPropertyChanged(cached, hpv, withVisibility)) {
                     event = generatePropertyModifiedEvent(hpv, cached, locale, resourceBundle, withVisibility);
                 } else {
-                    LOGGER.warn("Historical property value did not change. Ignore");
-                    LOGGER.warn("  was:" + hpv);
+                    LOGGER.debug("Historical property value did not change. Ignore");
+                    LOGGER.debug("  was:" + hpv);
                 }
                 cachedValues.put(key, hpv);
             }
-            
+
             if (event != null) {
                 result.events.add(event);
             }
 
             i++;
         }
-        
+
         return result;
     }
-    
+
     private static ClientApiHistoricalPropertyResults.Event generateGenericEvent(HistoricalPropertyValue hpv) {
         ClientApiHistoricalPropertyResults.Event event = new ClientApiHistoricalPropertyResults.Event();
         event.timestamp = hpv.getTimestamp();
@@ -372,20 +371,23 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         event.modifiedBy = ((modifiedByEntry != null) ? toClientApiValue(modifiedByEntry.getValue()).toString() : null);
         return event;
     }
-    
-    private static ClientApiHistoricalPropertyResults.Event generatePropertyAddedEvent(HistoricalPropertyValue hpv,
-        Locale locale, ResourceBundle resourceBundle, boolean withVisibility) {
-        
-        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv); 
+
+    private static ClientApiHistoricalPropertyResults.Event generatePropertyAddedEvent(
+            HistoricalPropertyValue hpv,
+            Locale locale,
+            ResourceBundle resourceBundle,
+            boolean withVisibility
+    ) {
+        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv);
         event.setEventType(ClientApiHistoricalPropertyResults.EventType.PROPERTY_ADDED);
         Map<String, String> fields = new HashMap<>();
-        
+
         Object value = hpv.getValue();
         if (value instanceof StreamingPropertyValue) {
             value = readStreamingPropertyValueForHistory((StreamingPropertyValue) value, locale, resourceBundle);
         }
         fields.put("value", toClientApiValue(value).toString());
-        
+
         if (withVisibility) {
             fields.put("visibility", removeWorkspaceVisibility(hpv.getPropertyVisibility().getVisibilityString()));
         }
@@ -393,15 +395,18 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         event.changed = null;
         return event;
     }
-    
-    private static ClientApiHistoricalPropertyResults.Event generatePropertyDeletedEvent(HistoricalPropertyValue hpv,
-        Locale locale, ResourceBundle resourceBundle, boolean withVisibility) {
-        
-        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv); 
+
+    private static ClientApiHistoricalPropertyResults.Event generatePropertyDeletedEvent(
+            HistoricalPropertyValue hpv,
+            Locale locale,
+            ResourceBundle resourceBundle,
+            boolean withVisibility
+    ) {
+
+        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv);
         event.setEventType(ClientApiHistoricalPropertyResults.EventType.PROPERTY_DELETED);
-        Map<String, String> fields = new HashMap<>();
         Map<String, String> changed = new HashMap<>();
-        
+
         Object value = hpv.getValue();
         if (value != null) {
             if (value instanceof StreamingPropertyValue) {
@@ -415,19 +420,23 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         }
         event.fields = null;
         event.changed = changed;
-        
+
         return event;
     }
-    
-    private static ClientApiHistoricalPropertyResults.Event generatePropertyModifiedEvent(HistoricalPropertyValue hpv,
-        HistoricalPropertyValue cached, Locale locale, ResourceBundle resourceBundle, boolean withVisibility) {
-        
-        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv); 
+
+    private static ClientApiHistoricalPropertyResults.Event generatePropertyModifiedEvent(
+            HistoricalPropertyValue hpv,
+            HistoricalPropertyValue cached,
+            Locale locale,
+            ResourceBundle resourceBundle,
+            boolean withVisibility
+    ) {
+        ClientApiHistoricalPropertyResults.Event event = generateGenericEvent(hpv);
         event.setEventType(ClientApiHistoricalPropertyResults.EventType.PROPERTY_MODIFIED);
-        
+
         Map<String, String> fields = new HashMap<>();
         Map<String, String> changed = new HashMap<>();
-        
+
         Object value = hpv.getValue();
         if (value instanceof StreamingPropertyValue) {
             value = readStreamingPropertyValueForHistory((StreamingPropertyValue) value, locale, resourceBundle);
@@ -436,7 +445,7 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         if (!hpv.getValue().equals(cached.getValue())) {
             changed.put("value", toClientApiValue(cached.getValue()).toString());
         }
-       
+
         if (withVisibility) {
             String currentVis = removeWorkspaceVisibility(hpv.getPropertyVisibility().getVisibilityString());
             String previousVis = removeWorkspaceVisibility(cached.getPropertyVisibility().getVisibilityString());
@@ -447,12 +456,15 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         }
         event.fields = fields;
         event.changed = changed;
-        
+
         return event;
     }
-    
-    private static boolean hasHistoricalPropertyChanged(HistoricalPropertyValue previous, HistoricalPropertyValue current,
-        boolean withVisibility) {
+
+    private static boolean hasHistoricalPropertyChanged(
+            HistoricalPropertyValue previous,
+            HistoricalPropertyValue current,
+            boolean withVisibility
+    ) {
         if (!current.getValue().equals(previous.getValue())) {
             return true;
         }
@@ -463,15 +475,17 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
         }
         return false;
     }
-    
+
     public static ClientApiHistoricalPropertyResults toClientApi(
             Iterable<HistoricalPropertyValue> historicalPropertyValues,
             Locale locale,
             ResourceBundle resourceBundle,
             boolean withVisibility
     ) {
-        return calculateHistoricalPropertyDeltas(historicalPropertyValues, locale, resourceBundle, withVisibility); 
-    };
+        return calculateHistoricalPropertyDeltas(historicalPropertyValues, locale, resourceBundle, withVisibility);
+    }
+
+    ;
 
     private static String readStreamingPropertyValueForHistory(
             StreamingPropertyValue spv,

--- a/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
+++ b/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
@@ -132,6 +132,9 @@ public class IngestRepository {
             ElementBuilder elementBuilder,
             EntityBuilder entityBuilder
     ) {
+        VisalloProperties.MODIFIED_BY.setProperty(elementBuilder, ingestOptions.getIngestUser().getUserId(), visibilityTranslator.getDefaultVisibility());
+        VisalloProperties.MODIFIED_DATE.setProperty(elementBuilder, new Date(), visibilityTranslator.getDefaultVisibility());
+
         for (PropertyAddition<?> propertyAddition : entityBuilder.getPropertyAdditions()) {
             if (propertyAddition.getValue() != null) {
                 elementBuilder.addPropertyValue(

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
@@ -71,6 +71,8 @@ public class ResolveTermEntity implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
+        Date now = new Date();
+
         String artifactHasEntityIri = ontologyRepository.getRequiredRelationshipIRIByIntent("artifactHasEntity", workspaceId);
 
         Workspace workspace = workspaceRepository.findById(workspaceId, user);
@@ -87,6 +89,8 @@ public class ResolveTermEntity implements ParameterizedHandler {
         Metadata metadata = new Metadata();
         Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
         VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, defaultVisibility);
+        VisalloProperties.MODIFIED_BY_METADATA.setMetadata(metadata, user.getUserId(), defaultVisibility);
+        VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(metadata, now, defaultVisibility);
         Vertex vertex;
         if (resolvedVertexId != null) {
             vertex = graph.getVertex(id, authorizations);
@@ -95,7 +99,7 @@ public class ResolveTermEntity implements ParameterizedHandler {
             VisalloProperties.CONCEPT_TYPE.setProperty(vertexMutation, conceptId, defaultVisibility);
             VisalloProperties.VISIBILITY_JSON.setProperty(vertexMutation, visibilityJson, defaultVisibility);
             VisalloProperties.MODIFIED_BY.setProperty(vertexMutation, user.getUserId(), defaultVisibility);
-            VisalloProperties.MODIFIED_DATE.setProperty(vertexMutation, new Date(), defaultVisibility);
+            VisalloProperties.MODIFIED_DATE.setProperty(vertexMutation, now, defaultVisibility);
             VisalloProperties.TITLE.addPropertyValue(vertexMutation, MULTI_VALUE_KEY, title, metadata, visalloVisibility.getVisibility());
 
             if (justificationText != null) {
@@ -112,7 +116,7 @@ public class ResolveTermEntity implements ParameterizedHandler {
 
         EdgeBuilder edgeBuilder = graph.prepareEdge(artifactVertex, vertex, artifactHasEntityIri, visalloVisibility.getVisibility());
         VisalloProperties.MODIFIED_BY.setProperty(edgeBuilder, user.getUserId(), defaultVisibility);
-        VisalloProperties.MODIFIED_DATE.setProperty(edgeBuilder, new Date(), defaultVisibility);
+        VisalloProperties.MODIFIED_DATE.setProperty(edgeBuilder, now, defaultVisibility);
         VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, visibilityJson, defaultVisibility);
         Edge edge = edgeBuilder.save(authorizations);
 


### PR DESCRIPTION
Ensure that built in properties are being set properly during RDF import, when using the generated ontology code, and when resolving entities.

1. RdfTripleImportHelper.java was missing metadata on the SOURCE property
2. Reduced ClientApiConverter.java warning messages to debug level
3. IngestRepository.java was missing modified by/date properties on entities
4. ResolveTermEntity.java was modified by/date metadata on the TITLE property

A much larger issue is to begin working through the codebase to migrate toward using the GraphUpdateContext, but I'm not sure a change that size is something we want to do toward the end of the release cycle. Once complete, it will take care of these issues where the built in properties have been missed.

- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions:
1. Import a file using RDF import and ensure that edge and vertex property history shows the proper metadata
2. Import data using code generated from the ontology and ensure that edge and vertex property history shows the proper metadata
3. Resolve an entity in text on the UI and ensure that the new vertex's property history shows the proper metadata

Points of Regression:
None

CHANGELOG
Fixed: Updated RdfTripleImportHelper, IngestRepository, and ResolveTermEntity to properly set metadata.
