### PR TITLE
Fix find path duplicating existing edges

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -825,7 +825,7 @@ define([
                     var lastNode = sourceId;
 
                     nodeIds.forEach(nodeId => {
-                        if (nodeId in nodesById) {
+                        if (nodeId in nodesById && nodeId !== lastNode) {
                             existingOrNewEdgeBetween(lastNode, nodeId, count);
                             lastNode = nodeId;
                             count = 0;

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -347,13 +347,13 @@ define([
                 $(document).trigger('displayInformation', { message: 'Too many paths to show, will display the first ' + MaxPathsToFocus })
             }
 
-            data.renderedPaths = data.paths.map(path => _.uniq(path.map(id => {
+            data.renderedPaths = data.paths.map(path => path.map(id => {
                 mappedIds[id] = mappedIds[id] || (
                     cy.getElementById(id).length
                         ? id : (collapsedNodes.filter(node => node.data('vertexIds').includes(id)).id() || id)
                 );
                 return mappedIds[id];
-            })));
+            }));
 
             this.setState({
                 paths: data

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/plugin.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/plugin.js
@@ -63,19 +63,10 @@ define([
     function addEdges(state, { productId, edges, workspaceId }) {
         const product = state.workspaces[workspaceId].products[productId];
         if (product && product.extendedData && product.extendedData.edges) {
-            return u({
-                    workspaces: {
-                        [workspaceId]: {
-                            products: {
-                                [productId]: {
-                                    extendedData: {
-                                        edges: edges
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }, state);
+            return u.updateIn(
+                `workspaces.${workspaceId}.products.${productId}.extendedData.edges`,
+                (prevEdges) => ({...prevEdges, ...edges})
+            , state)
         }
 
         return state;

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/store-changes.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/store-changes.js
@@ -18,18 +18,20 @@ define([
                     productSelectors.getProducts(state).forEach(product => {
                         if (product.extendedData) {
                             const { vertices, edges } = product.extendedData;
-                            const addEdges = [];
+                            const addEdges = {};
+
                             _.each(newEdges, (edge, id) => {
                                 if (edge !== null && !(id in edges)) {
                                     if (edge.inVertexId in vertices && edge.outVertexId in vertices) {
-                                        addEdges.push({
+                                        addEdges[id]= {
                                             edgeId: id,
                                             ..._.pick(edge, 'inVertexId', 'outVertexId', 'label')
-                                        });
+                                        };
                                     }
                                 }
                             })
-                            if (addEdges.length) {
+
+                            if (Object.keys(addEdges).length) {
                                 _.defer(() => {
                                     store.dispatch({
                                         type: 'PRODUCT_ADD_EDGE_IDS',


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Also fixed a case where a path going in and out of a collapsed node multiple times would create an extra edge that didn't exist.

Testing Instructions:  
1. Create 5 vertices with 1 edge between each (4 edges total). 
1. Collapse the second and fourth vertices. 
1. Find a path between the first and fifth vertices.

no CHANGELOG
