### PR TITLE
Fix justification snippets having some text outside the scroll area

### DIFF
--- a/web/war/src/main/webapp/js/detail/properties/properties.js
+++ b/web/war/src/main/webapp/js/detail/properties/properties.js
@@ -763,7 +763,7 @@ define([
                             valueSpan.textContent = truncatedValueCache[property.key] && truncatedValueCache[property.key].expanded
                                 ? textContent : truncatedTextContent;
 
-                            if (textContent !== truncatedTextContent) {
+                            if (textContent.trim() !== truncatedTextContent) {
                                 truncatedValueCache[property.key] = {
                                     expanded: false,
                                     ...truncatedValueCache[property.key],

--- a/web/war/src/main/webapp/js/util/vertex/justification/viewerTpl.hbs
+++ b/web/war/src/main/webapp/js/util/vertex/justification/viewerTpl.hbs
@@ -3,7 +3,9 @@
 {{else}}
 
   {{#if sourceMetadata}}
-    {{{sourceMetadata.snippet}}}
+      <div class="justification-snippet">
+        {{{sourceMetadata.snippet}}}
+      </div>
     {{#if linkToSource}}
         <a class="sourceInfoTitle" href="#"></a>
     {{/if}}

--- a/web/war/src/main/webapp/less/fields/fields.less
+++ b/web/war/src/main/webapp/less/fields/fields.less
@@ -94,6 +94,9 @@ input.invalid:focus, textarea.invalid:focus, select.invalid:focus {
     .text {
       display:block;
       font-style: italic;
+      .selection {
+        .justification-selection;
+      }
       &:before { content: '\201C'; }
       &:after { content: '\201D'; }
     }

--- a/web/war/src/main/webapp/less/util/popovers/propertyInfo.less
+++ b/web/war/src/main/webapp/less/util/popovers/propertyInfo.less
@@ -67,6 +67,10 @@
       .justification-snippet {
         max-height: 6em;
         overflow-y: auto;
+
+        .selection {
+          .justification-selection;
+        }
       }
 
       .sourceInfoTitle {

--- a/web/war/src/main/webapp/less/util/popovers/propertyInfo.less
+++ b/web/war/src/main/webapp/less/util/popovers/propertyInfo.less
@@ -63,9 +63,8 @@
     }
     .justificationValue {
       padding: 0.25em 0.5em;
-      
-      .selection {
-        display: block;
+
+      .justification-snippet {
         max-height: 6em;
         overflow-y: auto;
       }


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Added a div to wrap justification snippets that have added extra context outside the span so that they are also within the scrolling container.

Testing Instructions: 
1. Resolve/justify a property with a portion of text. 
1. Highlight a larger portion of text that encompasses the previous selection and use that to resolve/justify something else. 
1. Verify the entire justification snippet is contained within the popover.

no CHANGELOG
