### PR TITLE
Don't clone the entire state when updating with many diffs

### DIFF
--- a/web/war/src/main/webapp/js/data/withReduxStore.js
+++ b/web/war/src/main/webapp/js/data/withReduxStore.js
@@ -117,10 +117,7 @@ That should not be possible as /user/me ensures a workspace is created in that c
      */
     function applyDiff(state, diff) {
         // Need to copy all changed paths, since jsonpatch mutates
-        // Straight clone is faster for many changes
-        let copy = diff.length > 25 ?
-            jsonpatch.deepClone(state) :
-            copyChangedPaths(state, diff);
+        let copy = copyChangedPaths(state, diff);
 
         const newState = jsonpatch.applyPatch(copy, diff).newDocument;
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Don't clone the state when patching redux store. This was more performant when there are many diffs to apply, but not worth components losing the ability to shallow compare their props and forcing extra re-renders.

no CHANGELOG
