### PR TITLE
Add right click menu support to saved search table rows

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTable.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTable.jsx
@@ -36,6 +36,7 @@ define([
         onTabClick: PropTypes.func,
         onHeaderClick: PropTypes.func,
         onRowClick: PropTypes.func,
+        onContextMenu: PropTypes.func,
         onColumnResize: PropTypes.func,
         onConfigureColumnsClick: PropTypes.func
     };

--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableContainer.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableContainer.jsx
@@ -25,7 +25,13 @@ define([
         }),
 
         (dispatch, props) => ({
-            onSetSelection: (selection) => dispatch(selectionActions.set(selection))
+            onSetSelection: (selection) => dispatch(selectionActions.set(selection)),
+            onVertexMenu: (element, vertexId, position) => {
+                $(element).trigger('showVertexContextMenu', { vertexId, position });
+            },
+            onEdgeMenu: (element, edgeIds, position) => {
+                $(element).trigger('showEdgeContextMenu', { edgeIds, position });
+            }
         })
     )(SavedSearchTableCard);
 

--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/SelectableRowRenderer.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/SelectableRowRenderer.jsx
@@ -8,14 +8,15 @@ define([], function() {
       className,
       columns,
       index,
-      isScrolling,
       onRowClick,
       onRowDoubleClick,
       onRowMouseOver,
       onRowMouseOut,
       rowData,
-      style
-    }, selected) {
+      style,
+      selected,
+      onContextMenu
+    }) {
         const a11yProps = {}
 
         if (
@@ -55,6 +56,7 @@ define([], function() {
                 {...a11yProps}
                 className={className}
                 style={style}
+                onContextMenu={(event) => { onContextMenu(event, index)}}
                 data-row-index={index}
             >
                 {columns}

--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/Table.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/table/Table.jsx
@@ -33,6 +33,7 @@ define([
             loadMoreRows: PropTypes.func,
             onHeaderClick: PropTypes.func,
             onRowClick: PropTypes.func,
+            onContextMenu: PropTypes.func,
             onColumnResize: PropTypes.func,
             onConfigureClick: PropTypes.func
         },
@@ -55,7 +56,7 @@ define([
                 scrollToIndex,
                 onRowsRendered,
                 onHeaderClick,
-                onRowClick,
+                onContextMenu,
                 onColumnResize,
                 onConfigureColumnsClick } = this.props;
             const rowCount = data.length;
@@ -86,7 +87,7 @@ define([
                                          rowHeight={({ index }) => data[index] && data[index].height || ROW_HEIGHT}
                                          rowCount={rowCount}
                                          rowGetter={({ index }) => data[index] || {}}
-                                         rowRenderer={(args) => SelectableRowRenderer(args, selected)}
+                                         rowRenderer={(args) => SelectableRowRenderer({ ...args, onContextMenu, selected })}
                                          scrollToIndex={scrollToIndex}
                                          onRowsRendered={onRowsRendered}
                                          ref={(ref) => {


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Also: 
1. Fixed table removing 'objectsSelected' event listeners from document on teardown.
1. Cleaned up unused variables.

CHANGELOG
Added: Right/Ctrl + click now brings up the element context menu when clicking rows inside a saved search table.
