### PR TITLE
Fix structured ingest date property form

### DIFF
--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/css/style.css
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/css/style.css
@@ -316,6 +316,15 @@
     width: 100%;
 }
 
+.com-visallo-csv .aux_fields.type-date label .format {
+    margin-bottom: 0;
+}
+
+.com-visallo-csv .aux_fields.type-date label a {
+    font-size: 0.8em;
+    margin-left: 0.5em;
+}
+
 .com-visallo-csv h1.help {
   font-size: 140%;
   color: #999;

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/auxillary/date.js
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/auxillary/date.js
@@ -40,18 +40,23 @@ define([
         this.defaultAttrs({
             inputSelector: 'input',
             formatSelector: 'input.format',
-            timezoneSelector: 'input.timezone',
+            timezoneSelector: 'select.timezone',
             selectSelector: 'select'
         });
 
         this.after('initialize', function() {
-            var f = formats(this.attr.property.dateOnly || false, this.attr.mapping.hints.format);
+            const f = formats(this.attr.property.displayType ? this.attr.property.displayType === 'dateOnly' : false, this.attr.mapping.hints.format);
+            const timezones = _.mapObject(F.timezone.list(), ({ offsetDisplay, dst }, timezone) => (
+                `${offsetDisplay} ${timezone}${dst ? '*' : ''}`
+            ));
 
             this.$node.html(template({
-                timezone: this.attr.mapping.hints.timezone || F.timezone.currentTimezone().name,
+                timezones,
                 formats: f,
                 format: this.attr.mapping.hints.format || f[0].format
             }));
+
+            this.select('timezoneSelector').val(this.attr.mapping.hints.timezone || F.timezone.currentTimezone().name);
 
             this.on('change keyup paste', {
                 inputSelector: this.onChange

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/messages.properties
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/messages.properties
@@ -36,6 +36,11 @@ csv.file_import.preview.help=Import Preview
 csv.file_import.preview.publish=Publish Elements Immediately
 csv.file_import.preview.truncated=Showing preview of the created elements in the first {0} rows
 
+csv.file_import.properties.auxiliary.date.format=Format
+csv.file_import.properties.auxiliary.date.timezone=Timezone
+csv.file_import.properties.auxiliary.date.format.help=Help with date formats
+
+
 activity.tasks.type.org-visallo-structured-ingest=Structured Ingest
 activity.tasks.type.com-visallo-structuredFile.searchRelated=Search Extracted
 activity.tasks.type.com-visallo-structuredFile.searchRelatedDifferentWorkspace=Entities were not extracted in this @{alias.case.lowerCase}

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/templates/auxillary/date.hbs
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/templates/auxillary/date.hbs
@@ -1,13 +1,20 @@
 <label class="half">
-  <a target="_blank" href="http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">Format</a>
+    {{ i18n 'csv.file_import.properties.auxiliary.date.format' }}
   <select>
     {{#each formats}}
     <option value="{{ format }}"{{#if selected}} selected{{/if}}>{{ example }}</option>
     {{/each}}
   </select>
   <input type="text" class="format" placeholder="Date Format" value="{{ format }}">
+  <a target="_blank" href="http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">
+      {{ i18n 'csv.file_import.properties.auxiliary.date.format.help' }}
+  </a>
 </label>
 <label class="half">
-  Timezone
-  <input type="text" placeholder="timezone" class="timezone" value="{{ timezone }}">
+  {{ i18n 'csv.file_import.properties.auxiliary.date.timezone' }}
+  <select class="timezone">
+      {{#each timezones}}
+          <option value={{@key}} {{#if selected}}selected{{/if}}>{{ this }}</option>
+      {{/each}}
+  </select>
 </label>


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

1. Fixed structured ingest date property form choosing wrong property to test whether it is dateOnly or dateTime.
1. Changed input for timezone to a select dropdown.
1. Moved date formatting help link to below format input.
<img alt="moved-help-link" src="https://cl.ly/3V0J0C2Z1d0w/Image%202017-08-30%20at%2010.51.01%20AM.png" height="200px"/>

CHANGELOG
Changed: Moved help link for date formatting from structured ingest property form to below the fields rather than in the format label.
Changed: Changed the timezone field when mapping date properties in structured ingest forms to a dropdown with all timezones.
