### PR TITLE
fix mime type gpw bailing when you have multiple configs in property file

### DIFF
--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/MimeTypeGraphPropertyWorker.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/MimeTypeGraphPropertyWorker.java
@@ -55,7 +55,8 @@ public abstract class MimeTypeGraphPropertyWorker extends GraphPropertyWorker {
             return false;
         }
 
-        if (VisalloProperties.MIME_TYPE.hasProperty(element, getMultiKey(property))) {
+        String metadataValue = VisalloProperties.MIME_TYPE_METADATA.getMetadataValue(property.getMetadata(), null);
+        if (metadataValue != null) {
             return false;
         }
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Testing Instructions: 
1) Have multiple text properties in ontology
2) Add text properties to configuration files so that MimeTypeGPW will work on them
(https://github.com/visallo/visallo/blob/master/core/core/src/main/java/org/visallo/core/ingest/graphProperty/MimeTypeGraphPropertyWorker.java#L24-L25)
3) Queue both text properties
4) Make sure both text properties have a mime type metadata

Points of Regression: N/A

CHANGELOG
Fixed: MimeType GPW only adding mime type as a metadata on the first text property when you have the GPW configured to work on multiple text properties