### PR TITLE
use property visibility of property used to determine mimetype when adding mimetype

### DIFF
--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/MimeTypeGraphPropertyWorker.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/MimeTypeGraphPropertyWorker.java
@@ -73,7 +73,7 @@ public abstract class MimeTypeGraphPropertyWorker extends GraphPropertyWorker {
 
         ExistingElementMutation<Vertex> m = ((Vertex) data.getElement()).prepareMutation();
         Metadata mimeTypeMetadata = data.createPropertyMetadata(getUser());
-        VisalloProperties.MIME_TYPE.addPropertyValue(m, getMultiKey(data.getProperty()), mimeType, mimeTypeMetadata, data.getVisibility());
+        VisalloProperties.MIME_TYPE.addPropertyValue(m, getMultiKey(data.getProperty()), mimeType, mimeTypeMetadata, data.getProperty().getVisibility());
         m.setPropertyMetadata(data.getProperty(), VisalloProperties.MIME_TYPE.getPropertyName(), mimeType, getVisibilityTranslator().getDefaultVisibility());
         m.save(getAuthorizations());
         getGraph().flush();


### PR DESCRIPTION
There are cases where the property used to determine the mime type differs in visibility from the vertex visibility. We should be using the visibility of the property used to determine mime type and not the vertex visibility.

- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

CHANGELOG
Changed: All properties added by MimeTypeGPW should use property visibility instead of the vertex visibility.
