### PR TITLE
Back-end collapse API - Convert generic JSON objects to Java POJOs for strong typing

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/workspace/MockWorkProductService.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workspace/MockWorkProductService.java
@@ -1,9 +1,10 @@
 package org.visallo.core.model.workspace;
 
-import org.json.JSONObject;
 import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.vertexium.Vertex;
+import org.visallo.core.model.workspace.product.GetExtendedDataParams;
+import org.visallo.core.model.workspace.product.WorkProductExtendedData;
 import org.visallo.core.model.workspace.product.WorkProductService;
 import org.visallo.core.user.User;
 
@@ -11,15 +12,15 @@ public class MockWorkProductService implements WorkProductService {
     public static final String KIND = "org.visallo.core.model.workspace.MockWorkProduct";
 
     @Override
-    public JSONObject getExtendedData(
+    public WorkProductExtendedData getExtendedData(
             Graph graph,
             Vertex workspaceVertex,
             Vertex productVertex,
-            JSONObject params,
+            GetExtendedDataParams params,
             User user,
             Authorizations authorizations
     ) {
-        return new JSONObject();
+        return new WorkProductExtendedData();
     }
 
     @Override

--- a/core/core-test/src/main/java/org/visallo/core/model/workspace/WorkspaceRepositoryTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workspace/WorkspaceRepositoryTestBase.java
@@ -5,9 +5,13 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.vertexium.*;
 import org.visallo.core.model.graph.VisibilityAndElementMutation;
-import org.visallo.core.model.ontology.*;
+import org.visallo.core.model.ontology.Concept;
+import org.visallo.core.model.ontology.OntologyProperty;
+import org.visallo.core.model.ontology.OntologyPropertyDefinition;
+import org.visallo.core.model.ontology.Relationship;
 import org.visallo.core.model.user.UserPropertyPrivilegeRepository;
 import org.visallo.core.model.workQueue.Priority;
+import org.visallo.core.model.workspace.product.GetExtendedDataParams;
 import org.visallo.core.model.workspace.product.Product;
 import org.visallo.core.user.User;
 import org.visallo.core.util.SandboxStatusUtil;
@@ -90,7 +94,7 @@ public abstract class WorkspaceRepositoryTestBase extends VisalloInMemoryTestBas
         );
         String productId = product.getId();
 
-        product = getWorkspaceRepository().findProductById(workspace.getWorkspaceId(), productId, new JSONObject(), true, user);
+        product = getWorkspaceRepository().findProductById(workspace.getWorkspaceId(), productId, new GetExtendedDataParams(), true, user);
         assertEquals("value1", product.getExtendedData().get("key1"));
         assertEquals("value2", product.getExtendedData().get("key2"));
         Object value3 = product.getExtendedData().get("key3");
@@ -106,7 +110,7 @@ public abstract class WorkspaceRepositoryTestBase extends VisalloInMemoryTestBas
         params.put("extendedData", extendedData);
         getWorkspaceRepository().addOrUpdateProduct(workspace.getWorkspaceId(), productId, null, null, params, user);
 
-        product = getWorkspaceRepository().findProductById(workspace.getWorkspaceId(), productId, new JSONObject(), true, user);
+        product = getWorkspaceRepository().findProductById(workspace.getWorkspaceId(), productId, new GetExtendedDataParams(), true, user);
         assertEquals(null, product.getExtendedData().get("key1"));
         assertEquals("value2b", product.getExtendedData().get("key2"));
         value3 = product.getExtendedData().get("key3");
@@ -456,7 +460,7 @@ public abstract class WorkspaceRepositoryTestBase extends VisalloInMemoryTestBas
         assertTrue(response.getFailures().isEmpty());
 
         if (vertexiumObject instanceof Element) {
-            assertEquals(SandboxStatus.PUBLIC, SandboxStatusUtil.getSandboxStatus((Element)vertexiumObject, workspace.getWorkspaceId()));
+            assertEquals(SandboxStatus.PUBLIC, SandboxStatusUtil.getSandboxStatus((Element) vertexiumObject, workspace.getWorkspaceId()));
         } else {
             SandboxStatus[] propertySandboxStatuses = SandboxStatusUtil.getPropertySandboxStatuses(Collections.singletonList((Property) vertexiumObject), workspace.getWorkspaceId());
             assertEquals(1, propertySandboxStatuses.length);
@@ -480,7 +484,7 @@ public abstract class WorkspaceRepositoryTestBase extends VisalloInMemoryTestBas
         assertEquals(expectedError, failures.get(0).getErrorMessage());
 
         if (vertexiumObject instanceof Element) {
-            assertEquals(SandboxStatus.PRIVATE, SandboxStatusUtil.getSandboxStatus((Element)vertexiumObject, workspace.getWorkspaceId()));
+            assertEquals(SandboxStatus.PRIVATE, SandboxStatusUtil.getSandboxStatus((Element) vertexiumObject, workspace.getWorkspaceId()));
         } else {
             SandboxStatus[] propertySandboxStatuses = SandboxStatusUtil.getPropertySandboxStatuses(Collections.singletonList((Property) vertexiumObject), workspace.getWorkspaceId());
             assertEquals(1, propertySandboxStatuses.length);

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/GraphPositionSingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/GraphPositionSingleValueVisalloProperty.java
@@ -1,0 +1,23 @@
+package org.visallo.core.model.properties.types;
+
+import org.visallo.core.util.JSONUtil;
+import org.visallo.web.clientapi.model.GraphPosition;
+
+public class GraphPositionSingleValueVisalloProperty extends SingleValueVisalloProperty<GraphPosition, String> {
+    public GraphPositionSingleValueVisalloProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public String wrap(GraphPosition value) {
+        return value.toJSONObject().toString();
+    }
+
+    @Override
+    public GraphPosition unwrap(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return GraphPosition.fromJSONObject(JSONUtil.parse(value.toString()));
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/IntegerSingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/IntegerSingleValueVisalloProperty.java
@@ -1,20 +1,10 @@
 package org.visallo.core.model.properties.types;
 
-import org.vertexium.Element;
-
 import java.util.Map;
 
 public class IntegerSingleValueVisalloProperty extends IdentitySingleValueVisalloProperty<Integer> {
     public IntegerSingleValueVisalloProperty(String key) {
         super(key);
-    }
-
-    public Integer getPropertyValue(Element element, Integer defaultValue) {
-        Integer nullable = getPropertyValue(element);
-        if (nullable == null) {
-            return defaultValue;
-        }
-        return nullable;
     }
 
     public Integer getPropertyValue(Map<String, Object> map, Integer defaultValue) {

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
@@ -71,6 +71,14 @@ public abstract class SingleValueVisalloProperty<TRaw, TGraph> extends VisalloPr
         return value != null ? getRawConverter().apply(value) : null;
     }
 
+    public final TRaw getPropertyValue(Element element, TRaw defaultValue) {
+        TRaw value = getPropertyValue(element);
+        if (value == null) {
+            value = defaultValue;
+        }
+        return value;
+    }
+
     public final TRaw getPropertyValueRequired(Element element) {
         checkNotNull(element, "Element cannot be null");
         Object value = element.getPropertyValue(getPropertyName());

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/StringListSingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/StringListSingleValueVisalloProperty.java
@@ -1,0 +1,25 @@
+package org.visallo.core.model.properties.types;
+
+import org.json.JSONArray;
+import org.visallo.core.util.JSONUtil;
+
+import java.util.List;
+
+public class StringListSingleValueVisalloProperty extends SingleValueVisalloProperty<List<String>, String> {
+    public StringListSingleValueVisalloProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public String wrap(List<String> value) {
+        return new JSONArray(value).toString();
+    }
+
+    @Override
+    public List<String> unwrap(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return JSONUtil.toStringList(JSONUtil.parseArray(value.toString()));
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/StringSingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/StringSingleValueVisalloProperty.java
@@ -1,6 +1,5 @@
 package org.visallo.core.model.properties.types;
 
-import org.vertexium.Element;
 import org.vertexium.Property;
 
 public class StringSingleValueVisalloProperty extends SingleValueVisalloProperty<String, String> {
@@ -24,14 +23,6 @@ public class StringSingleValueVisalloProperty extends SingleValueVisalloProperty
             return null;
         }
         return value.toString();
-    }
-
-    public String getPropertyValue(Element element, String defaultValue) {
-        String value = getPropertyValue(element);
-        if (value == null) {
-            return defaultValue;
-        }
-        return value;
     }
 }
 

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisibilityJsonVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisibilityJsonVisalloProperty.java
@@ -1,18 +1,9 @@
 package org.visallo.core.model.properties.types;
 
 import org.visallo.web.clientapi.model.VisibilityJson;
-import org.vertexium.Element;
 
 public class VisibilityJsonVisalloProperty extends ClientApiSingleValueVisalloProperty<VisibilityJson> {
     public VisibilityJsonVisalloProperty(String key) {
         super(key, VisibilityJson.class);
-    }
-
-    public VisibilityJson getPropertyValue(Element element, VisibilityJson defaultValue) {
-        VisibilityJson value = getPropertyValue(element);
-        if (value == null) {
-            return defaultValue;
-        }
-        return value;
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
@@ -28,6 +28,7 @@ import org.visallo.core.model.termMention.TermMentionRepository;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.model.workspace.product.GetExtendedDataParams;
 import org.visallo.core.model.workspace.product.Product;
 import org.visallo.core.model.workspace.product.WorkProductService;
 import org.visallo.core.security.VisalloVisibility;
@@ -1091,7 +1092,7 @@ public abstract class WorkspaceRepository {
 
     public abstract void deleteProduct(String workspaceId, String productId, User user);
 
-    public abstract Product findProductById(String workspaceId, String productId, JSONObject params, boolean includeExtended, User user);
+    public abstract Product findProductById(String workspaceId, String productId, GetExtendedDataParams params, boolean includeExtended, User user);
 
     public abstract InputStream getProductPreviewById(String workspaceId, String productId, User user);
 

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/GetExtendedDataParams.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/GetExtendedDataParams.java
@@ -1,0 +1,24 @@
+package org.visallo.core.model.workspace.product;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+public class GetExtendedDataParams implements ClientApiObject {
+    private boolean includeVertices;
+    private boolean includeEdges;
+
+    public boolean isIncludeVertices() {
+        return includeVertices;
+    }
+
+    public void setIncludeVertices(boolean includeVertices) {
+        this.includeVertices = includeVertices;
+    }
+
+    public boolean isIncludeEdges() {
+        return includeEdges;
+    }
+
+    public void setIncludeEdges(boolean includeEdges) {
+        this.includeEdges = includeEdges;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/UpdateProductEdgeOptions.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/UpdateProductEdgeOptions.java
@@ -1,0 +1,6 @@
+package org.visallo.core.model.workspace.product;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+public class UpdateProductEdgeOptions implements ClientApiObject {
+}

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductEdge.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductEdge.java
@@ -1,0 +1,51 @@
+package org.visallo.core.model.workspace.product;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+public class WorkProductEdge implements ClientApiObject {
+    private String edgeId;
+    private String label;
+    private String outVertexId;
+    private String inVertexId;
+    private boolean unauthorized;
+
+    public void setEdgeId(String edgeId) {
+        this.edgeId = edgeId;
+    }
+
+    public String getEdgeId() {
+        return edgeId;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setOutVertexId(String outVertexId) {
+        this.outVertexId = outVertexId;
+    }
+
+    public String getOutVertexId() {
+        return outVertexId;
+    }
+
+    public void setInVertexId(String inVertexId) {
+        this.inVertexId = inVertexId;
+    }
+
+    public String getInVertexId() {
+        return inVertexId;
+    }
+
+    public void setUnauthorized(boolean unauthorized) {
+        this.unauthorized = unauthorized;
+    }
+
+    public boolean isUnauthorized() {
+        return unauthorized;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductExtendedData.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductExtendedData.java
@@ -1,0 +1,26 @@
+package org.visallo.core.model.workspace.product;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+import java.util.Map;
+
+public class WorkProductExtendedData implements ClientApiObject {
+    private Map<String, ? extends WorkProductVertex> vertices;
+    private Map<String, ? extends WorkProductEdge> edges;
+
+    public void setVertices(Map<String, ? extends WorkProductVertex> vertices) {
+        this.vertices = vertices;
+    }
+
+    public Map<String, ? extends WorkProductVertex> getVertices() {
+        return vertices;
+    }
+
+    public void setEdges(Map<String, ? extends WorkProductEdge> edges) {
+        this.edges = edges;
+    }
+
+    public Map<String, ? extends WorkProductEdge> getEdges() {
+        return edges;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductService.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductService.java
@@ -13,11 +13,11 @@ public interface WorkProductService {
      * Get custom extended data from the work product. This does not include the extended data stored on the
      * product itself.
      */
-    JSONObject getExtendedData(
+    WorkProductExtendedData getExtendedData(
             Graph graph,
             Vertex workspaceVertex,
             Vertex productVertex,
-            JSONObject params,
+            GetExtendedDataParams params,
             User user,
             Authorizations authorizations
     );

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductVertex.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductVertex.java
@@ -1,0 +1,51 @@
+package org.visallo.core.model.workspace.product;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+public class WorkProductVertex implements ClientApiObject {
+    private String id;
+    private boolean visible;
+    private String title;
+    private String type;
+    private boolean unauthorized;
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setUnauthorized(boolean unauthorized) {
+        this.unauthorized = unauthorized;
+    }
+
+    public boolean isUnauthorized() {
+        return unauthorized;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
+++ b/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
@@ -1,6 +1,7 @@
 package org.visallo.core.util;
 
 import com.google.common.collect.Lists;
+import org.json.JSONObject;
 import org.vertexium.*;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.type.GeoPoint;
@@ -599,5 +600,9 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
                 id.getTableName(),
                 id.getRowId()
         );
+    }
+
+    public static JSONObject clientApiToJSONObject(Object obj) {
+        return new JSONObject(clientApiToString(obj));
     }
 }

--- a/core/core/src/main/java/org/visallo/core/util/JSONUtil.java
+++ b/core/core/src/main/java/org/visallo/core/util/JSONUtil.java
@@ -118,6 +118,9 @@ public class JSONUtil {
     }
 
     public static List<String> toStringList(JSONArray arr) {
+        if (arr == null) {
+            return null;
+        }
         List<String> result = new ArrayList<String>();
         for (int i = 0; i < arr.length(); i++) {
             result.add(arr.getString(i));
@@ -125,8 +128,15 @@ public class JSONUtil {
         return result;
     }
 
+    public static Set<String> toStringSet(JSONArray arr) {
+        if (arr == null) {
+            return null;
+        }
+        return new HashSet<>(toStringList(arr));
+    }
+
     public static List<Object> toList(JSONArray arr) {
-        List<Object> list = new ArrayList();
+        List<Object> list = new ArrayList<>();
         for (int i = 0; i < arr.length(); i++) {
             list.add(fromJson(arr.get(i)));
         }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/GraphPosition.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/GraphPosition.java
@@ -1,10 +1,16 @@
 package org.visallo.web.clientapi.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.json.JSONObject;
 
 public class GraphPosition {
     private int x;
     private int y;
+
+    @JsonCreator
+    protected GraphPosition() {
+
+    }
 
     public GraphPosition(JSONObject position) {
         this(position.optInt("x", 0), position.optInt("y", 0));
@@ -82,5 +88,12 @@ public class GraphPosition {
         json.put("x", x);
         json.put("y", y);
         return json;
+    }
+
+    public static GraphPosition fromJSONObject(JSONObject json) {
+        if (json == null) {
+            return null;
+        }
+        return new GraphPosition(json);
     }
 }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/util/ClientApiConverter.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/util/ClientApiConverter.java
@@ -1,6 +1,8 @@
 package org.visallo.web.clientapi.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.visallo.web.clientapi.model.DirectoryEntity;
@@ -100,6 +102,15 @@ public class ClientApiConverter {
     public static <T> T toClientApi(String str, Class<T> clazz) {
         try {
             return ObjectMapperFactory.getInstance().readValue(str, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not parse '" + str + "' to class '" + clazz.getName() + "'", e);
+        }
+    }
+
+    public static <T> Map<String, T> toClientApiMap(String str, Class<T> clazz) {
+        try {
+            MapType typeRef = TypeFactory.defaultInstance().constructMapType(HashMap.class, String.class, clazz);
+            return ObjectMapperFactory.getInstance().readValue(str, typeRef);
         } catch (IOException e) {
             throw new RuntimeException("Could not parse '" + str + "' to class '" + clazz.getName() + "'", e);
         }

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphProductOntology.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphProductOntology.java
@@ -1,17 +1,17 @@
 package org.visallo.web.product.graph;
 
 
-import org.visallo.core.model.properties.types.JsonArraySingleValueVisalloProperty;
-import org.visallo.core.model.properties.types.JsonSingleValueVisalloProperty;
+import org.visallo.core.model.properties.types.GraphPositionSingleValueVisalloProperty;
+import org.visallo.core.model.properties.types.StringListSingleValueVisalloProperty;
 import org.visallo.core.model.properties.types.StringSingleValueVisalloProperty;
 
 public class GraphProductOntology {
     public static final String IRI = "http://visallo.org/workspace/product/graph";
     public static final String CONCEPT_TYPE_COMPOUND_NODE = "http://visallo.org/workspace/product/graph#compoundNode";
 
-    public static final JsonSingleValueVisalloProperty ENTITY_POSITION = new JsonSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#entityPosition");
+    public static final GraphPositionSingleValueVisalloProperty ENTITY_POSITION = new GraphPositionSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#entityPosition");
     public static final StringSingleValueVisalloProperty PARENT_NODE = new StringSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#parentNode");
-    public static final JsonArraySingleValueVisalloProperty NODE_CHILDREN = new JsonArraySingleValueVisalloProperty("http://visallo.org/workspace/product/graph#nodeChildren");
+    public static final StringListSingleValueVisalloProperty NODE_CHILDREN = new StringListSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#nodeChildren");
     public static final StringSingleValueVisalloProperty NODE_TITLE = new StringSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#nodeTitle");
 
 }

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphUpdateProductEdgeOptions.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphUpdateProductEdgeOptions.java
@@ -1,0 +1,41 @@
+package org.visallo.web.product.graph.model;
+
+import org.visallo.core.model.workspace.product.UpdateProductEdgeOptions;
+import org.visallo.web.clientapi.model.GraphPosition;
+
+import java.util.List;
+
+public class GraphUpdateProductEdgeOptions extends UpdateProductEdgeOptions {
+    private String id;
+    private List<String> children;
+    private String parent;
+    private GraphPosition pos;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<String> getChildren() {
+        return children;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public void setPos(GraphPosition pos) {
+        this.pos = pos;
+    }
+
+    public GraphPosition getPos() {
+        return pos;
+    }
+}

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphWorkProductExtendedData.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphWorkProductExtendedData.java
@@ -1,0 +1,17 @@
+package org.visallo.web.product.graph.model;
+
+import org.visallo.core.model.workspace.product.WorkProductExtendedData;
+
+import java.util.Map;
+
+public class GraphWorkProductExtendedData extends WorkProductExtendedData {
+    private Map<String, GraphWorkProductVertex> compoundNodes;
+
+    public void setCompoundNodes(Map<String, GraphWorkProductVertex> compoundNodes) {
+        this.compoundNodes = compoundNodes;
+    }
+
+    public Map<String, GraphWorkProductVertex> getCompoundNodes() {
+        return compoundNodes;
+    }
+}

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphWorkProductVertex.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphWorkProductVertex.java
@@ -1,0 +1,36 @@
+package org.visallo.web.product.graph.model;
+
+import org.visallo.core.model.workspace.product.WorkProductVertex;
+import org.visallo.web.clientapi.model.GraphPosition;
+
+import java.util.List;
+
+public class GraphWorkProductVertex extends WorkProductVertex {
+    private String parent;
+    private GraphPosition pos;
+    private List<String> children;
+
+    public void setChildren(List<String> children) {
+        this.children = children;
+    }
+
+    public List<String> getChildren() {
+        return children;
+    }
+
+    public void setPos(GraphPosition pos) {
+        this.pos = pos;
+    }
+
+    public GraphPosition getPos() {
+        return pos;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+}

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/RemoveVerticesParams.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/RemoveVerticesParams.java
@@ -1,0 +1,36 @@
+package org.visallo.web.product.graph.model;
+
+import org.visallo.web.clientapi.model.ClientApiObject;
+
+public class RemoveVerticesParams implements ClientApiObject {
+    private boolean removeChildren;
+    private BroadcastOptions broadcastOptions;
+
+    public boolean isRemoveChildren() {
+        return removeChildren;
+    }
+
+    public void setRemoveChildren(boolean removeChildren) {
+        this.removeChildren = removeChildren;
+    }
+
+    public BroadcastOptions getBroadcastOptions() {
+        return broadcastOptions;
+    }
+
+    public void setBroadcastOptions(BroadcastOptions broadcastOptions) {
+        this.broadcastOptions = broadcastOptions;
+    }
+
+    public static class BroadcastOptions {
+        private boolean preventBroadcastToSourceGuid;
+
+        public boolean isPreventBroadcastToSourceGuid() {
+            return preventBroadcastToSourceGuid;
+        }
+
+        public void setPreventBroadcastToSourceGuid(boolean preventBroadcastToSourceGuid) {
+            this.preventBroadcastToSourceGuid = preventBroadcastToSourceGuid;
+        }
+    }
+}

--- a/web/plugins/map-product/src/main/java/org/visallo/web/product/map/MapWorkProductService.java
+++ b/web/plugins/map-product/src/main/java/org/visallo/web/product/map/MapWorkProductService.java
@@ -1,22 +1,22 @@
 package org.visallo.web.product.map;
 
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.vertexium.*;
 import org.visallo.core.model.graph.ElementUpdateContext;
 import org.visallo.core.model.graph.GraphUpdateContext;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.workspace.WorkspaceProperties;
+import org.visallo.core.model.workspace.product.UpdateProductEdgeOptions;
+import org.visallo.core.model.workspace.product.WorkProductEdge;
 import org.visallo.core.model.workspace.product.WorkProductServiceHasElementsBase;
-import org.visallo.core.util.JSONUtil;
+import org.visallo.core.model.workspace.product.WorkProductVertex;
 
-import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Singleton
-public class MapWorkProductService extends WorkProductServiceHasElementsBase {
+public class MapWorkProductService extends WorkProductServiceHasElementsBase<WorkProductVertex, WorkProductEdge> {
     public static final String KIND = "org.visallo.web.product.map.MapWorkProduct";
 
     @Inject
@@ -27,23 +27,34 @@ public class MapWorkProductService extends WorkProductServiceHasElementsBase {
     }
 
     @Override
-    protected void updateProductEdge(ElementUpdateContext<Edge> elemCtx, JSONObject update, Visibility visibility) {
+    protected WorkProductEdge createWorkProductEdge() {
+        return new WorkProductEdge();
     }
 
-    protected void setEdgeJson(Edge propertyVertexEdge, JSONObject vertex) {
+    @Override
+    protected WorkProductVertex createWorkProductVertex() {
+        return new WorkProductVertex();
+    }
+
+    @Override
+    protected void updateProductEdge(ElementUpdateContext<Edge> elemCtx, UpdateProductEdgeOptions update, Visibility visibility) {
+    }
+
+    @Override
+    protected void populateVertexWithWorkspaceEdge(Edge propertyVertexEdge, WorkProductVertex vertex) {
     }
 
     public void updateVertices(
             GraphUpdateContext ctx,
             Vertex productVertex,
-            JSONObject updateVertices,
+            Map<String, UpdateProductEdgeOptions> updateVertices,
             Visibility visibility
     ) {
         if (updateVertices != null) {
             @SuppressWarnings("unchecked")
-            List<String> vertexIds = Lists.newArrayList(updateVertices.keys());
+            Set<String> vertexIds = updateVertices.keySet();
             for (String id : vertexIds) {
-                JSONObject updateData = updateVertices.getJSONObject(id);
+                UpdateProductEdgeOptions updateData = updateVertices.get(id);
                 String edgeId = getEdgeId(productVertex.getId(), id);
                 EdgeBuilderByVertexId edgeBuilder = ctx.getGraph().prepareEdge(
                         edgeId,
@@ -60,12 +71,13 @@ public class MapWorkProductService extends WorkProductServiceHasElementsBase {
     public void removeVertices(
             GraphUpdateContext ctx,
             Vertex productVertex,
-            JSONArray removeVertices,
+            String[] removeVertices,
             Authorizations authorizations
     ) {
         if (removeVertices != null) {
-            JSONUtil.toList(removeVertices)
-                    .forEach(id -> ctx.getGraph().softDeleteEdge(getEdgeId(productVertex.getId(), (String) id), authorizations));
+            for (String id : removeVertices) {
+                ctx.getGraph().softDeleteEdge(getEdgeId(productVertex.getId(), id), authorizations);
+            }
         }
     }
 

--- a/web/plugins/map-product/src/main/java/org/visallo/web/product/map/routes/RemoveVertices.java
+++ b/web/plugins/map-product/src/main/java/org/visallo/web/product/map/routes/RemoveVertices.java
@@ -5,7 +5,6 @@ import com.google.inject.Singleton;
 import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Required;
-import org.json.JSONArray;
 import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.vertexium.Vertex;
@@ -53,7 +52,7 @@ public class RemoveVertices implements ParameterizedHandler {
 
     @Handle
     public ClientApiSuccess handle(
-            @Required(name = "vertexIds[]") String[] vertexIds,
+            @Required(name = "vertexIds[]") String[] vertexIdsToRemove,
             @Required(name = "productId") String productId,
             @ActiveWorkspaceId String workspaceId,
             @SourceGuid String sourceGuid,
@@ -66,9 +65,7 @@ public class RemoveVertices implements ParameterizedHandler {
         );
         try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.HIGH, user, authorizations)) {
             Vertex productVertex = graph.getVertex(productId, authorizations);
-            JSONArray removeVertices = new JSONArray(vertexIds);
-
-            mapWorkProductService.removeVertices(ctx, productVertex, removeVertices, authorizations);
+            mapWorkProductService.removeVertices(ctx, productVertex, vertexIdsToRemove, authorizations);
         } catch (Exception e) {
             throw new VisalloException("Could not remove vertices from product: " + productId);
         }

--- a/web/plugins/map-product/src/main/java/org/visallo/web/product/map/routes/UpdateVertices.java
+++ b/web/plugins/map-product/src/main/java/org/visallo/web/product/map/routes/UpdateVertices.java
@@ -5,7 +5,6 @@ import com.google.inject.Singleton;
 import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Required;
-import org.json.JSONObject;
 import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.vertexium.Vertex;
@@ -18,15 +17,18 @@ import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.model.workspace.Workspace;
 import org.visallo.core.model.workspace.WorkspaceHelper;
 import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.model.workspace.product.UpdateProductEdgeOptions;
 import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
-import org.visallo.core.util.JSONUtil;
+import org.visallo.core.util.ClientApiConverter;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
 import org.visallo.web.clientapi.model.ClientApiWorkspace;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.SourceGuid;
 import org.visallo.web.product.map.MapWorkProductService;
+
+import java.util.Map;
 
 @Singleton
 public class UpdateVertices implements ParameterizedHandler {
@@ -68,7 +70,7 @@ public class UpdateVertices implements ParameterizedHandler {
             @SourceGuid String sourceGuid,
             User user
     ) throws Exception {
-        JSONObject updateVertices = new JSONObject(updates);
+        Map<String, UpdateProductEdgeOptions> updateVertices = ClientApiConverter.toClientApiMap(updates, UpdateProductEdgeOptions.class);
         Authorizations authorizations = authorizationRepository.getGraphAuthorizations(
                 user,
                 WorkspaceRepository.VISIBILITY_STRING,
@@ -77,7 +79,7 @@ public class UpdateVertices implements ParameterizedHandler {
 
         workspaceHelper.updateEntitiesOnWorkspace(
                 workspaceId,
-                JSONUtil.toStringList(updateVertices.names()),
+                updateVertices.keySet(),
                 user
         );
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/product/ProductGet.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/product/ProductGet.java
@@ -6,8 +6,8 @@ import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Optional;
 import com.v5analytics.webster.annotations.Required;
-import org.json.JSONObject;
 import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.model.workspace.product.GetExtendedDataParams;
 import org.visallo.core.model.workspace.product.Product;
 import org.visallo.core.user.User;
 import org.visallo.core.util.ClientApiConverter;
@@ -32,7 +32,9 @@ public class ProductGet implements ParameterizedHandler {
             @ActiveWorkspaceId String workspaceId,
             User user
     ) throws Exception {
-        JSONObject params = paramsStr == null ? new JSONObject() : new JSONObject(paramsStr);
+        GetExtendedDataParams params = paramsStr == null
+                ? new GetExtendedDataParams()
+                : ClientApiConverter.toClientApi(paramsStr, GetExtendedDataParams.class);
         Product product = workspaceRepository.findProductById(workspaceId, productId, params, includeExtended, user);
         return ClientApiConverter.toClientApiProduct(product);
     }


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

This commit gives API users a type safe interface to collapse entities.

CHANGELOG
Changed: Back-end collapse API - Convert generic JSON objects to Java POJOs for strong typing