### PR TITLE
Fix extra product requests

### DIFF
--- a/web/war/src/main/webapp/js/product/ProductDetail.jsx
+++ b/web/war/src/main/webapp/js/product/ProductDetail.jsx
@@ -14,20 +14,17 @@ define([
                 componentPath: PropTypes.string.isRequired
             }).isRequired
         },
+
         getInitialState: () => ({ Component: null }),
-        requestComponent(props) {
-            props.onGetProduct(props.product.id)
-            if (props.extension.componentPath !== this.props.extension.componentPath || !this.state.Component) {
-                this.setState({ Component: null })
-                Promise.require(props.extension.componentPath).then((C) => this.setState({ Component: C }))
-            }
-        },
+
         componentDidMount() {
-            this.requestComponent(this.props);
+            this.requestComponent(this.props, !this.props.product.extendedData);
         },
+
         componentWillReceiveProps(nextProps) {
-            this.requestComponent(nextProps);
+            this.requestComponent(nextProps, nextProps.product !== this.props.product);
         },
+
         render() {
             var { Component } = this.state;
             var { product, editable } = this.props;
@@ -42,6 +39,17 @@ define([
                         title={title}
                         padding={this.props.padding} />)
             )
+        },
+
+        requestComponent(props, requestProduct) {
+            if (requestProduct) {
+                props.onGetProduct(props.product.id);
+            }
+
+            if (props.extension.componentPath !== this.props.extension.componentPath || !this.state.Component) {
+                this.setState({ Component: null })
+                Promise.require(props.extension.componentPath).then((C) => this.setState({ Component: C }))
+            }
         }
     });
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

* If multiple people had access to a case and a product in that case was updated, everyone would re-request the product with extended data even if they had not viewed or were not currently viewing the product. Changed this to only request extended data if the client has the product selected. If the client has the product cached then we request the product without extended data to clear those keys. Otherwise we do nothing.
* Fixed a race condition in ProductDetail that would end up in a new product request with extended data.

Testing Instructions: Load a product then view the network tab. There should only be one request where `product?productId=<productId>.



1. As User A create a case and add a graph product with a vertex.
1. Share the case to User B
1. As User A load a different case.
1. As User B, in a separate session, load the shared case and move the vertex.
1. As User A check the network panel shows a `product?productId=<productId>` request with an `extendedData: false` header

Points of Regression: Switching cases/selecting work products. Product list not updating correctly

CHANGELOG
Fixed: Performance issues where work products were loaded multiple times unnecessarily.
