### PR TITLE
Fixed: add related because of strong types

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
@@ -237,7 +237,7 @@ define([
                 const parent = product.localData && product.localData.rootId || 'root';
                 dispatch(api.updatePositions({
                     productId,
-                    updateVertices: _.mapObject(updateVertices, id => ({ id, parent, pos: nextPosition()}))
+                    updateVertices: _.mapObject(updateVertices, o => ({ id: o.id, parent, pos: nextPosition()}))
                 }));
             }
 


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

The front-end was sending { id: { id: "123" } } which was causing JSON deserialization to fail.

no change log needed, broken in this version