### PR TITLE
fix match any executing search when no option is selected and fix error when reexecuting match any queries

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filterItem.js
+++ b/web/war/src/main/webapp/js/search/filters/filterItem.js
@@ -108,7 +108,7 @@ define([
                 }
 
                 valid = valid && _.every(filter.values, function(v) {
-                    return !_.isUndefined(v);
+                    return !_.isUndefined(v) && !_.isEmpty(v);
                 });
             }
 
@@ -274,7 +274,7 @@ define([
                     node.eq(0).show();
                     node.eq(1).hide();
                     if (self.filter.predicate === PREDICATES.IN) {
-                        self.filter.values = [self.filter.values];
+                        self.filter.values = _.isArray(self.filter.values) ? self.filter.values : [self.filter.values];
                     }
                 } else {
                     node.hide();
@@ -299,7 +299,7 @@ define([
                             onlySearchable: true,
                             focus: false,
                             property: property,
-                            value: self.filter.values[i]
+                            value: !self.filter.values[i] ? [] : self.filter.values[i]
                         });
                     })
                 }


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions: 
1. Execute a search for Gender Matches Any Male then add Female
2. Select Matches Any and then reselect it
3. -> Search results change to No results
4. Change it to Has Gender
5. Switch back to Matches Any
Those steps should all have the same results returned

Points of Regression: N/A

CHANGELOG
Fixed: Match any executing search when no option is selected
Fixed: Error when re-executing Match any searches
