### PR TITLE
Migrate a visallo 3.x instance to visallo 4.0

### DIFF
--- a/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
@@ -54,8 +54,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class VisalloBootstrap extends AbstractModule {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(VisalloBootstrap.class);
-    private static final String GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY = "visallo.graph.version";
-    private static final Integer GRAPH_METADATA_VISALLO_GRAPH_VERSION = 3;
+    public static final String GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY = "visallo.graph.version";
+    private static final Integer GRAPH_METADATA_VISALLO_GRAPH_VERSION = 4;
 
     private static VisalloBootstrap visalloBootstrap;
 

--- a/tools/migrations/core/pom.xml
+++ b/tools/migrations/core/pom.xml
@@ -3,20 +3,20 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>visallo-tools-migrations</artifactId>
         <groupId>org.visallo</groupId>
+        <artifactId>visallo-tools-migrations</artifactId>
         <version>3.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>visallo-tools-migration-workspace-to-workproduct</artifactId>
-    <name>Visallo: Tools - Migration Workspace to Work Product</name>
-    <packaging>jar</packaging>
+    <artifactId>visallo-tools-migration-core</artifactId>
+    <name>Visallo: Tools - Migration Core</name>
 
     <dependencies>
         <dependency>
             <groupId>org.visallo</groupId>
-            <artifactId>visallo-tools-migration-core</artifactId>
+            <artifactId>visallo-core</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/tools/migrations/core/src/main/java/org/visallo/tools/migrations/MigrationBase.java
+++ b/tools/migrations/core/src/main/java/org/visallo/tools/migrations/MigrationBase.java
@@ -1,0 +1,66 @@
+package org.visallo.tools.migrations;
+
+import org.vertexium.Graph;
+import org.vertexium.GraphFactory;
+import org.visallo.core.cmdline.CommandLineTool;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.exception.VisalloException;
+
+import static org.visallo.core.bootstrap.VisalloBootstrap.GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY;
+
+public abstract class MigrationBase extends CommandLineTool {
+    private Graph graph = null;
+
+    @Override
+    public final int run(String[] args, boolean initFramework) throws Exception {
+        return super.run(args, initFramework);
+    }
+
+    @Override
+    protected final int run() throws Exception {
+        graph = getGraph();
+        try {
+            Object visalloGraphVersionObj = graph.getMetadata(GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY);
+            if (visalloGraphVersionObj == null) {
+                throw new VisalloException("No graph metadata version set");
+            } else if (visalloGraphVersionObj instanceof Integer) {
+                Integer visalloGraphVersion = (Integer) visalloGraphVersionObj;
+                if (getFinalGraphVersion().equals(visalloGraphVersion)) {
+                    throw new VisalloException("Migration has already completed. Graph version: " + visalloGraphVersion);
+                } else if (!getNeededGraphVersion().equals(visalloGraphVersion)) {
+                    throw new VisalloException("Migration can only run from version " + getNeededGraphVersion() +
+                            ". Current graph version = " + visalloGraphVersion);
+                }
+            }
+
+            if (migrate(graph)) {
+                graph.setMetadata(GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY, getFinalGraphVersion());
+            }
+
+            graph.flush();
+            afterMigrate(graph);
+
+            return 0;
+        } finally {
+            graph.shutdown();
+        }
+    }
+
+    public abstract Integer getNeededGraphVersion();
+
+    public abstract Integer getFinalGraphVersion();
+
+    protected abstract boolean migrate(Graph graph);
+
+    protected void afterMigrate(Graph graph) {
+    }
+
+    @Override
+    public Graph getGraph() {
+        if (graph == null) {
+            GraphFactory factory = new GraphFactory();
+            graph = factory.createGraph(getConfiguration().getSubset(Configuration.GRAPH_PROVIDER));
+        }
+        return graph;
+    }
+}

--- a/tools/migrations/core/src/main/java/org/visallo/tools/migrations/MigrationBase.java
+++ b/tools/migrations/core/src/main/java/org/visallo/tools/migrations/MigrationBase.java
@@ -31,6 +31,8 @@ public abstract class MigrationBase extends CommandLineTool {
                     throw new VisalloException("Migration can only run from version " + getNeededGraphVersion() +
                             ". Current graph version = " + visalloGraphVersion);
                 }
+            } else {
+                throw new VisalloException("Unexpected value for graph version: " + visalloGraphVersionObj);
             }
 
             if (migrate(graph)) {

--- a/tools/migrations/pom.xml
+++ b/tools/migrations/pom.xml
@@ -14,7 +14,9 @@
     <name>Visallo: Tools: Migrations</name>
 
     <modules>
+        <module>core</module>
         <module>workspace-to-workproduct</module>
         <module>graph-version-bump</module>
+        <module>predefined-to-dynamic-ontology</module>
     </modules>
 </project>

--- a/tools/migrations/predefined-to-dynamic-ontology/pom.xml
+++ b/tools/migrations/predefined-to-dynamic-ontology/pom.xml
@@ -3,20 +3,25 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>visallo-tools-migrations</artifactId>
         <groupId>org.visallo</groupId>
+        <artifactId>visallo-tools-migrations</artifactId>
         <version>3.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>visallo-tools-migration-workspace-to-workproduct</artifactId>
-    <name>Visallo: Tools - Migration Workspace to Work Product</name>
-    <packaging>jar</packaging>
+    <artifactId>visallo-tools-migration-predefined-to-dynamic-ontology</artifactId>
+    <name>Visallo: Tools - Migration Predefined to Dynamic Ontology</name>
 
     <dependencies>
         <dependency>
             <groupId>org.visallo</groupId>
             <artifactId>visallo-tools-migration-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.visallo</groupId>
+            <artifactId>visallo-model-vertexium</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/tools/migrations/predefined-to-dynamic-ontology/src/main/java/org/visallo/tools/migrations/PredefinedToDynamicOntology.java
+++ b/tools/migrations/predefined-to-dynamic-ontology/src/main/java/org/visallo/tools/migrations/PredefinedToDynamicOntology.java
@@ -35,6 +35,7 @@ public class PredefinedToDynamicOntology extends MigrationBase {
 
     @Override
     protected boolean migrate(Graph graph) {
+        LOGGER.info("Updating Vertexium property definitions.");
         graph.defineProperty(OntologyProperties.DISPLAY_NAME.getPropertyName())
                 .dataType(String.class)
                 .textIndexHint(TextIndexHint.EXACT_MATCH)
@@ -62,10 +63,15 @@ public class PredefinedToDynamicOntology extends MigrationBase {
     @Override
     protected void afterMigrate(Graph graph) {
         if (graph instanceof GraphWithSearchIndex) {
+            LOGGER.info("Re-indexing ontology elements...");
+
             VisalloBootstrap bootstrap = VisalloBootstrap.bootstrap(getConfiguration());
             SearchIndex searchIndex = ((GraphWithSearchIndex) graph).getSearchIndex();
             Authorizations authorizations = graph.createAuthorizations(VisalloVisibility.SUPER_USER_VISIBILITY_STRING, OntologyRepository.VISIBILITY_STRING);
-            graph.getVerticesWithPrefix(VertexiumOntologyRepository.ID_PREFIX, authorizations).forEach(vertex -> searchIndex.addElement(graph, vertex, authorizations));
+            graph.getVerticesWithPrefix(VertexiumOntologyRepository.ID_PREFIX, authorizations).forEach(vertex -> {
+                LOGGER.debug("Adding vertex %s to search index.", vertex.getId());
+                searchIndex.addElement(graph, vertex, authorizations);
+            });
             searchIndex.flush(graph);
         }
     }

--- a/tools/migrations/predefined-to-dynamic-ontology/src/main/java/org/visallo/tools/migrations/PredefinedToDynamicOntology.java
+++ b/tools/migrations/predefined-to-dynamic-ontology/src/main/java/org/visallo/tools/migrations/PredefinedToDynamicOntology.java
@@ -1,0 +1,72 @@
+package org.visallo.tools.migrations;
+
+import com.beust.jcommander.Parameters;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.GraphWithSearchIndex;
+import org.vertexium.TextIndexHint;
+import org.vertexium.search.SearchIndex;
+import org.visallo.core.bootstrap.VisalloBootstrap;
+import org.visallo.core.cmdline.CommandLineTool;
+import org.visallo.core.model.ontology.OntologyProperties;
+import org.visallo.core.model.ontology.OntologyRepository;
+import org.visallo.core.security.VisalloVisibility;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.vertexium.model.ontology.VertexiumOntologyRepository;
+
+@Parameters(commandDescription = "Migrate from a strictly predefined ontology to a dynamic ontology")
+public class PredefinedToDynamicOntology extends MigrationBase {
+    private static VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(PredefinedToDynamicOntology.class);
+
+    public static void main(String[] args) throws Exception {
+        CommandLineTool.main(new PredefinedToDynamicOntology(), args, false);
+    }
+
+    @Override
+    public Integer getNeededGraphVersion() {
+        return 3;
+    }
+
+    @Override
+    public Integer getFinalGraphVersion() {
+        return 4;
+    }
+
+    @Override
+    protected boolean migrate(Graph graph) {
+        graph.defineProperty(OntologyProperties.DISPLAY_NAME.getPropertyName())
+                .dataType(String.class)
+                .textIndexHint(TextIndexHint.EXACT_MATCH)
+                .define();
+        graph.defineProperty(OntologyProperties.INTENT.getPropertyName())
+                .dataType(String.class)
+                .textIndexHint(TextIndexHint.EXACT_MATCH)
+                .define();
+        graph.defineProperty(OntologyProperties.USER_VISIBLE.getPropertyName())
+                .dataType(Boolean.TYPE)
+                .define();
+        graph.defineProperty(OntologyProperties.SEARCHABLE.getPropertyName())
+                .dataType(Boolean.TYPE)
+                .define();
+        graph.defineProperty(OntologyProperties.SORTABLE.getPropertyName())
+                .dataType(Boolean.TYPE)
+                .define();
+        graph.defineProperty(OntologyProperties.ADDABLE.getPropertyName())
+                .dataType(Boolean.TYPE)
+                .define();
+
+        return true;
+    }
+
+    @Override
+    protected void afterMigrate(Graph graph) {
+        if (graph instanceof GraphWithSearchIndex) {
+            VisalloBootstrap bootstrap = VisalloBootstrap.bootstrap(getConfiguration());
+            SearchIndex searchIndex = ((GraphWithSearchIndex) graph).getSearchIndex();
+            Authorizations authorizations = graph.createAuthorizations(VisalloVisibility.SUPER_USER_VISIBILITY_STRING, OntologyRepository.VISIBILITY_STRING);
+            graph.getVerticesWithPrefix(VertexiumOntologyRepository.ID_PREFIX, authorizations).forEach(vertex -> searchIndex.addElement(graph, vertex, authorizations));
+            searchIndex.flush(graph);
+        }
+    }
+}

--- a/tools/migrations/predefined-to-dynamic-ontology/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
+++ b/tools/migrations/predefined-to-dynamic-ontology/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
@@ -1,0 +1,1 @@
+org.visallo.tools.migrations.WorkspacesToWorkProduct

--- a/tools/migrations/predefined-to-dynamic-ontology/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
+++ b/tools/migrations/predefined-to-dynamic-ontology/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
@@ -1,1 +1,1 @@
-org.visallo.tools.migrations.WorkspacesToWorkProduct
+org.visallo.tools.migrations.PredefinedToDynamicOntology

--- a/tools/migrations/workspace-to-workproduct/src/main/java/org/visallo/tools/migrations/WorkspacesToWorkProduct.java
+++ b/tools/migrations/workspace-to-workproduct/src/main/java/org/visallo/tools/migrations/WorkspacesToWorkProduct.java
@@ -4,12 +4,8 @@ import com.beust.jcommander.Parameters;
 import org.json.JSONObject;
 import org.vertexium.*;
 import org.vertexium.query.GraphQuery;
-import org.vertexium.query.Query;
 import org.vertexium.query.QueryResultsIterable;
-import org.visallo.core.bootstrap.VisalloBootstrap;
 import org.visallo.core.cmdline.CommandLineTool;
-import org.visallo.core.config.Configuration;
-import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.workspace.WorkspaceProperties;
 import org.visallo.core.model.workspace.WorkspaceRepository;
@@ -17,16 +13,13 @@ import org.visallo.core.security.VisalloVisibility;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
-import java.util.EnumSet;
-
-import static org.visallo.core.util.StreamUtil.stream;
 import static org.visallo.core.model.workspace.WorkspaceProperties.WORKSPACE_TO_PRODUCT_RELATIONSHIP_IRI;
+import static org.visallo.core.util.StreamUtil.stream;
 
 @Parameters(commandDescription = "Migrate workspaces to work products")
-public class WorkspacesToWorkProduct extends CommandLineTool {
+public class WorkspacesToWorkProduct extends MigrationBase {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(WorkspacesToWorkProduct.class);
 
-    private static final String VISALLO_GRAPH_VERSION = "visallo.graph.version";
     private static final String GRAPH_KIND = "org.visallo.web.product.graph.GraphWorkProduct";
     private static final String EDGE_POSITION = "http://visallo.org/workspace/product/graph#entityPosition";
     private static final String GRAPH_VISIBLE = "http://visallo.org/workspace#toEntity/visible";
@@ -36,97 +29,73 @@ public class WorkspacesToWorkProduct extends CommandLineTool {
     private static final Integer VISALLO_GRAPH_VERSION_NEEDS_MIGRATION = 1;
     private static final Integer VISALLO_GRAPH_VERSION_BUMP = 2;
 
-    private Graph graph = null;
-
     public static void main(String[] args) throws Exception {
         CommandLineTool.main(new WorkspacesToWorkProduct(), args, false);
     }
 
     @Override
-    protected int run() throws Exception {
-        VisalloBootstrap bootstrap = VisalloBootstrap.bootstrap(getConfiguration());
-        graph = getGraph();
-        try {
-
-            Object visalloGraphVersionObj = graph.getMetadata(VISALLO_GRAPH_VERSION);
-            if (visalloGraphVersionObj == null) {
-                throw new VisalloException("No graph metadata version set");
-            } else if (visalloGraphVersionObj instanceof Integer) {
-                Integer visalloGraphVersion = (Integer) visalloGraphVersionObj;
-                if (VISALLO_GRAPH_VERSION_BUMP.equals(visalloGraphVersion)) {
-                    throw new VisalloException("Migration has already completed. Graph version: " + visalloGraphVersion);
-                } else if (!VISALLO_GRAPH_VERSION_NEEDS_MIGRATION.equals(visalloGraphVersion)) {
-                    throw new VisalloException("Migration can only run from version " + VISALLO_GRAPH_VERSION_NEEDS_MIGRATION +
-                            ". Current graph version = " + visalloGraphVersion);
-                }
-            }
-
-            Authorizations authorizations = graph.createAuthorizations(VisalloVisibility.SUPER_USER_VISIBILITY_STRING);
-            GraphQuery query = graph.query(authorizations);
-            QueryResultsIterable<Vertex> workspaceVertices = query.has(VisalloProperties.CONCEPT_TYPE.getPropertyName(), WorkspaceProperties.WORKSPACE_CONCEPT_IRI).vertices();
-
-            stream(workspaceVertices)
-                    .forEach(workspace -> {
-                        LOGGER.info("Found a workspace: %s", workspace.getId());
-
-                        VertexBuilder productVertex = graph.prepareVertex(workspace.getVisibility());
-                        VisalloProperties.CONCEPT_TYPE.setProperty(
-                                productVertex,
-                                WorkspaceProperties.PRODUCT_CONCEPT_IRI,
-                                workspace.getVisibility()
-                        );
-                        WorkspaceProperties.TITLE.setProperty(productVertex, "Migrated", workspace.getVisibility());
-                        WorkspaceProperties.PRODUCT_KIND.setProperty(productVertex, GRAPH_KIND, workspace.getVisibility());
-                        String productId = productVertex.getVertexId();
-                        productVertex.save(authorizations);
-                        EdgeBuilderByVertexId workspaceToProductEdge = graph.prepareEdge(workspace.getId() + "_hasProduct_" + productId, workspace.getId(), productId,
-                                WORKSPACE_TO_PRODUCT_RELATIONSHIP_IRI, workspace.getVisibility());
-
-                        workspaceToProductEdge.save(authorizations);
-                        LOGGER.info("Creating product: %s", productId);
-
-
-                        stream(workspace.getEdgeInfos(Direction.OUT, authorizations))
-                                .forEach(edgeInfo -> {
-                                    if (edgeInfo.getLabel().equals(WorkspaceRepository.WORKSPACE_TO_ENTITY_RELATIONSHIP_IRI)) {
-
-                                        Edge edge = getGraph().getEdge(edgeInfo.getEdgeId(), authorizations);
-                                        if (edge != null && edge.getPropertyValue(GRAPH_VISIBLE).equals(true)) {
-                                            LOGGER.info("\tCreating entity: %s", edgeInfo.getVertexId());
-
-                                            String edgeId = productId + "_hasVertex_" + edgeInfo.getVertexId();
-                                            EdgeBuilderByVertexId productToEntityEdge = graph.prepareEdge(
-                                                    edgeId,
-                                                    productId,
-                                                    edgeInfo.getVertexId(),
-                                                    PRODUCT_TO_ENTITY_RELATIONSHIP_IRI,
-                                                    workspace.getVisibility()
-                                            );
-                                            JSONObject position = new JSONObject();
-                                            position.put("x", positionForProperty(edge, GRAPH_POSITION_X));
-                                            position.put("y", positionForProperty(edge, GRAPH_POSITION_Y));
-                                            productToEntityEdge.setProperty(EDGE_POSITION, position.toString(), workspace.getVisibility());
-                                            productToEntityEdge.save(authorizations);
-                                        }
-                                    }
-                                });
-                    });
-
-            graph.setMetadata(VISALLO_GRAPH_VERSION, VISALLO_GRAPH_VERSION_BUMP);
-            return 0;
-        } finally {
-            graph.shutdown();
-        }
+    public Integer getNeededGraphVersion() {
+        return VISALLO_GRAPH_VERSION_NEEDS_MIGRATION;
     }
 
+    @Override
+    public Integer getFinalGraphVersion() {
+        return VISALLO_GRAPH_VERSION_BUMP;
+    }
 
     @Override
-    public Graph getGraph() {
-        if (graph == null) {
-            GraphFactory factory = new GraphFactory();
-            graph = factory.createGraph(getConfiguration().getSubset(Configuration.GRAPH_PROVIDER));
-        }
-        return graph;
+    protected boolean migrate(Graph graph) {
+        Authorizations authorizations = graph.createAuthorizations(VisalloVisibility.SUPER_USER_VISIBILITY_STRING);
+        GraphQuery query = graph.query(authorizations);
+        QueryResultsIterable<Vertex> workspaceVertices = query.has(VisalloProperties.CONCEPT_TYPE.getPropertyName(), WorkspaceProperties.WORKSPACE_CONCEPT_IRI).vertices();
+
+        stream(workspaceVertices)
+                .forEach(workspace -> {
+                    LOGGER.info("Found a workspace: %s", workspace.getId());
+
+                    VertexBuilder productVertex = graph.prepareVertex(workspace.getVisibility());
+                    VisalloProperties.CONCEPT_TYPE.setProperty(
+                            productVertex,
+                            WorkspaceProperties.PRODUCT_CONCEPT_IRI,
+                            workspace.getVisibility()
+                    );
+                    WorkspaceProperties.TITLE.setProperty(productVertex, "Migrated", workspace.getVisibility());
+                    WorkspaceProperties.PRODUCT_KIND.setProperty(productVertex, GRAPH_KIND, workspace.getVisibility());
+                    String productId = productVertex.getVertexId();
+                    productVertex.save(authorizations);
+                    EdgeBuilderByVertexId workspaceToProductEdge = graph.prepareEdge(workspace.getId() + "_hasProduct_" + productId, workspace.getId(), productId,
+                            WORKSPACE_TO_PRODUCT_RELATIONSHIP_IRI, workspace.getVisibility());
+
+                    workspaceToProductEdge.save(authorizations);
+                    LOGGER.info("Creating product: %s", productId);
+
+
+                    stream(workspace.getEdgeInfos(Direction.OUT, authorizations))
+                            .forEach(edgeInfo -> {
+                                if (edgeInfo.getLabel().equals(WorkspaceRepository.WORKSPACE_TO_ENTITY_RELATIONSHIP_IRI)) {
+
+                                    Edge edge = getGraph().getEdge(edgeInfo.getEdgeId(), authorizations);
+                                    if (edge != null && edge.getPropertyValue(GRAPH_VISIBLE).equals(true)) {
+                                        LOGGER.info("\tCreating entity: %s", edgeInfo.getVertexId());
+
+                                        String edgeId = productId + "_hasVertex_" + edgeInfo.getVertexId();
+                                        EdgeBuilderByVertexId productToEntityEdge = graph.prepareEdge(
+                                                edgeId,
+                                                productId,
+                                                edgeInfo.getVertexId(),
+                                                PRODUCT_TO_ENTITY_RELATIONSHIP_IRI,
+                                                workspace.getVisibility()
+                                        );
+                                        JSONObject position = new JSONObject();
+                                        position.put("x", positionForProperty(edge, GRAPH_POSITION_X));
+                                        position.put("y", positionForProperty(edge, GRAPH_POSITION_Y));
+                                        productToEntityEdge.setProperty(EDGE_POSITION, position.toString(), workspace.getVisibility());
+                                        productToEntityEdge.save(authorizations);
+                                    }
+                                }
+                            });
+                });
+        return true;
     }
 
     private int positionForProperty(Edge edge, String name) {


### PR DESCRIPTION
With the ontology updates, we now need the `intent` property to be indexed in the search engine. This migration will change the field definition in Vertexium and then reindex all of the ontology vertices.

While I was writing the migration, I noticed that a few other fields (USER_VISIBLE, SEARCHABLE...) were defined improperly as strings so I fixed those too. 

- [x] joeferner
- [x] sfeng88
- [ ] mwizeman joeybrk372 jharwig

Testing Instructions:
1. Shut down a running Visallo 3.x instance
2. Upgrade to Visallo 4.x
3. Run the new migration 
4. Start Visallo and ensure that the system starts properly and all data is maintained

CHANGELOG
Added: Migration script to update an existing Visallo 3.x installation to Visallo 4.x
