### PR TITLE
Initialize GraphUpdateProductEdgeOptions children to a new array list

### DIFF
--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphWorkProductService.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphWorkProductService.java
@@ -232,10 +232,10 @@ public class GraphWorkProductService extends WorkProductServiceHasElementsBase<G
 
             String edgeId = getEdgeId(productVertex.getId(), vertexId);
             ctx.getOrCreateEdgeAndUpdate(edgeId, productVertex.getId(),
-                                         vertexId,
-                                         WorkspaceProperties.PRODUCT_TO_ENTITY_RELATIONSHIP_IRI,
-                                         visibility,
-                                         elemCtx -> updateProductEdge(elemCtx, params, visibility)
+                    vertexId,
+                    WorkspaceProperties.PRODUCT_TO_ENTITY_RELATIONSHIP_IRI,
+                    visibility,
+                    elemCtx -> updateProductEdge(elemCtx, params, visibility)
             );
 
             ctx.flush();
@@ -270,7 +270,7 @@ public class GraphWorkProductService extends WorkProductServiceHasElementsBase<G
             String edgeId = getEdgeId(productVertex.getId(), id);
 
             //undoing compound node removal
-            if (updateData.getChildren() != null && !ctx.getGraph().doesVertexExist(id, authorizations)) {
+            if (updateData.hasChildren() && !ctx.getGraph().doesVertexExist(id, authorizations)) {
                 addCompoundNode(ctx, productVertex, updateData, user, visibility, authorizations);
             }
 
@@ -509,9 +509,8 @@ public class GraphWorkProductService extends WorkProductServiceHasElementsBase<G
                 GraphProductOntology.PARENT_NODE.updateProperty(elemCtx, parent, visibility);
             }
 
-            List<String> children = update.getChildren();
-            if (children != null) {
-                GraphProductOntology.NODE_CHILDREN.updateProperty(elemCtx, children, visibility);
+            if (update.hasChildren()) {
+                GraphProductOntology.NODE_CHILDREN.updateProperty(elemCtx, update.getChildren(), visibility);
             }
         }
     }

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphUpdateProductEdgeOptions.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/model/GraphUpdateProductEdgeOptions.java
@@ -3,11 +3,12 @@ package org.visallo.web.product.graph.model;
 import org.visallo.core.model.workspace.product.UpdateProductEdgeOptions;
 import org.visallo.web.clientapi.model.GraphPosition;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class GraphUpdateProductEdgeOptions extends UpdateProductEdgeOptions {
     private String id;
-    private List<String> children;
+    private List<String> children = new ArrayList<>();
     private String parent;
     private GraphPosition pos;
 
@@ -37,5 +38,9 @@ public class GraphUpdateProductEdgeOptions extends UpdateProductEdgeOptions {
 
     public GraphPosition getPos() {
         return pos;
+    }
+
+    public boolean hasChildren() {
+        return children != null && children.size() > 0;
     }
 }

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/routes/UpdateVertices.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/routes/UpdateVertices.java
@@ -87,7 +87,7 @@ public class UpdateVertices implements ParameterizedHandler {
 
         Set<String> vertices = updateVertices.keySet();
         vertices = vertices.stream()
-                .filter(id -> updateVertices.get(id).getChildren() == null)
+                .filter(id -> !updateVertices.get(id).hasChildren())
                 .collect(Collectors.toSet());
         workspaceHelper.updateEntitiesOnWorkspace(
                 workspaceId,


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

If GraphUpdateProductEdgeOptions has no children there was no way to add children because children was null. This commit initializes children allowing users of this class to add children.

No changelog need because this class is newer than the last release