### PR TITLE
fix saved search table not using updated saved search configs on refresh

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableCard.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableCard.jsx
@@ -187,6 +187,12 @@ define([
                         url: search.url
                     };
 
+                    const configuration = {
+                        ...item.configuration,
+                        searchParameters: search.parameters
+                    };
+                    item.configuration = configuration;
+
                     if (tableSettings && tableSettings[searchId]) {
                         tableView = {
                             ...tableSettings[searchId],


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions:
Steps to reproduce using demo data:
1) Create a saved search of all person concepts and name it "people"
2) Add a Saved Search table card to the dashboard and configure the table with the "people" saved search
3) Go to the search box and run the "people" saved search
4) Update the saved search by adding "kira" in the text box
5) Refresh the dashboard

Points of Regression: N/A

CHANGELOG
Fixed: Table dashboard card not using updated saved search configurations on refresh 
