### PR TITLE
update delete relationship subtitle to be consistent with delete entity subtitle

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -167,7 +167,7 @@ detail.toolbar.delete=Delete
 detail.toolbar.delete.entity=Delete Entity
 detail.toolbar.delete.entity.subtitle=Remove from @{alias.case} and Delete
 detail.toolbar.delete.edge=Delete Relationship
-detail.toolbar.delete.edge.subtitle=Delete this Relationship in @{alias.case}
+detail.toolbar.delete.edge.subtitle=Remove from @{alias.case} and Delete
 
 detail.toolbar.add.comment=Comment
 detail.toolbar.add.comment.entity.subtitle=Add New Comment to Entity


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions: When you delete a relationship from the element inspector, make sure the subtitle is `Remove from Case and Delete`

Points of Regression: N/A

CHANGELOG
Fixed: delete relationship subtitle to be consistent with delete entity subtitle on the element inspector
