### PR TITLE
Fix alignment of icons in glyph select dropdown

### DIFF
--- a/web/war/src/main/webapp/js/components/GlyphSelector.jsx
+++ b/web/war/src/main/webapp/js/components/GlyphSelector.jsx
@@ -140,8 +140,9 @@ define([
                 backgroundSize: option.backgroundSize,
                 width: option.width,
                 height: option.height,
-                transform: `scale(${option.scale})`,
-                transformOrigin: '0 50%',
+                transform: `scale(${option.scale}) translate(0, -50%)`,
+                transformOrigin: '0 0',
+                top: '50%',
                 margin: '0'
             }}></div>{option[labelKey]}</div>
         );


### PR DESCRIPTION
- [x] joeferner
- [x] sfeng88
- [x] mwizeman joeybrk372 jharwig

Testing Instructions: Create new concept and open icon dropdown, the icons should not be half-off the row

NO CHANGELOG – dynamics ontology new