### PR TITLE
Hide compound properties from search filter selectors

### DIFF
--- a/web/war/src/main/webapp/js/components/ontology/PropertySelector.jsx
+++ b/web/war/src/main/webapp/js/components/ontology/PropertySelector.jsx
@@ -25,6 +25,7 @@ define([
             filter: PropTypes.shape({
                 conceptId: PropTypes.string,
                 relationshipId: PropTypes.string,
+                hideCompound: PropTypes.bool,
                 addable: PropTypes.bool,
                 userVisible: PropTypes.bool,
                 searchable: PropTypes.bool,
@@ -76,6 +77,9 @@ define([
                     const relationshipProp = relationshipProps && relationshipProps[p.title];
                     formProps.domain = filter.relationshipId;
                     test = test && Boolean(relationshipProp);
+                }
+                if (test && filter && filter.hideCompound) {
+                    test = test && !p.dependentPropertyIris;
                 }
                 if (test && filter && filter.rollupCompound && p.dependentPropertyIris) {
                     dependentPropertyIris.push(...p.dependentPropertyIris);

--- a/web/war/src/main/webapp/js/search/dashboard/aggregation.js
+++ b/web/war/src/main/webapp/js/search/dashboard/aggregation.js
@@ -442,7 +442,9 @@ define([
                     selectedProperty: options.selected && ontology.properties.byTitle[options.selected] || null,
                     properties: self.filterProperties(propertiesToFilter),
                     showAdminProperties: true,
-                    placeholder: options.placeholder || ''
+                    placeholder: options.placeholder || '',
+                    rollupCompound: false,
+                    hideCompound: true
                 });
             });
         };

--- a/web/war/src/main/webapp/js/search/filters/filterItem.js
+++ b/web/war/src/main/webapp/js/search/filters/filterItem.js
@@ -375,7 +375,9 @@ define([
                 properties: this.attr.properties,
                 onlySearchable: true,
                 creatable: false,
-                placeholder: i18n('search.filters.add_filter.placeholder')
+                placeholder: i18n('search.filters.add_filter.placeholder'),
+                rollupCompound: false,
+                hideCompound: true
             });
         };
 

--- a/web/war/src/main/webapp/js/search/sort.js
+++ b/web/war/src/main/webapp/js/search/sort.js
@@ -98,6 +98,8 @@ define([
                 creatable: false,
                 onlySearchable: true,
                 onlySortable: true,
+                rollupCompound: false,
+                hideCompound: true,
                 placeholder: i18n('search.sort.placeholder')
             });
         };

--- a/web/war/src/main/webapp/js/util/ontology/propertySelect.js
+++ b/web/war/src/main/webapp/js/util/ontology/propertySelect.js
@@ -6,11 +6,12 @@
  * @attr {Array.<object>=} properties The ontology properties to populate the list with, if not provided will use visible properties
  * @attr {string} [placeholder=Select Property] the placeholder text to display
  * @attr {boolean} [creatable=true] Allow creation of new properties if the user has ONTOLOGY_ADD privilege
- * @attr {boolean} [limitParentConceptId=''] Only show properties that are attached to this concept or it's descendents
+ * @attr {boolean} [limitParentConceptId=''] Only show properties that are attached to this concept or it's descendants
  * @attr {boolean} [onlySearchable=false] Only show properties that have searchable attribute equal to true in ontology
  * @attr {boolean} [onlySortable=false] Only show properties that have sortable attribute equal to true in ontology
  * @attr {string} [onlyDataTypes=[]] Only show properties that have matching data type in ontology
- * @attr {boolean} [rollupCompound=true] Hide all dependant properties and only show the compound/parent fields
+ * @attr {boolean} [hideCompound=false] Hide all compound/parent fields
+ * @attr {boolean} [rollupCompound=true] Hide all dependent properties and only show the compound/parent fields
  * @attr {boolean} [focus=false] Activate the field for focus when finished rendering
  * @attr {string} [selectedProperty=''] Default the selection to this property IRI
  * @fires module:components/PropertySelect#propertyselected
@@ -87,6 +88,7 @@ define([
             const {
                 filter = {},
                 rollupCompound = true,
+                hideCompound = false,
                 focus,
                 placeholder,
                 properties,
@@ -119,7 +121,7 @@ define([
             this.attacher = attacher()
                 .node(this.node)
                 .params({
-                    filter: { ...filter, rollupCompound },
+                    filter: { ...filter, rollupCompound, hideCompound },
                     value: this.attr.selectedProperty,
                     autofocus: focus === true,
                     creatable: this.attr.creatable !== false,


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Search sort/filter by property fields should only show searchable, non-compound properties and dependent properties should be listed.

Points of Regression: Any property creation/selection instances

CHANGELOG
Added: You can pass a boolean `hideCompound` attribute to `components/propertySelect` to hide compound/parent properties from the list of options. (Defaults to false)
