### PR TITLE
fix date time not showing up in the correct local timezone

### DIFF
--- a/web/war/src/main/webapp/js/util/formatters.js
+++ b/web/war/src/main/webapp/js/util/formatters.js
@@ -767,7 +767,7 @@ define([
                 if (_.isDate(numberOrString)) {
                     dateInLocale = numberOrString;
                 } else {
-                    dateInLocale = new Date(moment.tz(numberOrString, tz.name).toISOString());
+                    dateInLocale = new Date(moment.tz(numberOrString, tz.name).format(dateFormat + ' ' + timeFormat));
                     if (isNaN(dateInLocale.getTime())) {
                         console.warn('Unable to parse date: ' + str);
                         return '';


### PR DESCRIPTION
- [ ] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Set local computer timezone to PDT
- Add a `day of death` property with the value `10/23/2017 1:00` and save
- Property should be displayed with the value `10/22/2017 22:00`

Points of Regression:
N/A

CHANGELOG
Fixed: Date time properties not being displayed in the correct local timezone
