### PR TITLE
expose props function to formula evaluator

### DIFF
--- a/docs/getting-started/ontology.md
+++ b/docs/getting-started/ontology.md
@@ -138,6 +138,7 @@ repository.ontology.owl.default.dir=$VISALLO_DIR/config/ontology-sample
         * `pluralDisplayName` The plural display name of type
         * `properties` The property iris defined on this type
     * `prop`: Function that accepts a property IRI and returns the display value.
+    * `props`: Function that accepts a property IRI and returns a list of all matching properties.
     * `propRaw`: Function that accepts a property IRI and returns the raw value.
 
     ```xml

--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -970,12 +970,6 @@ define([
             props: function(vertex, name, optionalKey) {
                 checkVertexAndPropertyNameArguments(vertex, name);
 
-                var hasKey = !_.isUndefined(optionalKey);
-
-                if (arguments.length === 3 && !hasKey) {
-                    throw new Error('Undefined key is not allowed. Remove parameter to return all named properties');
-                }
-
                 name = V.propName(name);
 
                 var ontologyProperty = getProperty(name),
@@ -1304,6 +1298,7 @@ define([
                 prop: _.wrap(V.prop, capture),
                 propRaw: _.wrap(V.propRaw, capture),
                 longestProp: _.wrap(V.longestProp, capture),
+                props: _.wrap(V.props, capture),
                 isEdge: V.isEdge
             }, undefined, { additionalScope: additionalScope });
         }

--- a/web/war/src/main/webapp/js/util/vertex/formula.js
+++ b/web/war/src/main/webapp/js/util/vertex/formula.js
@@ -11,7 +11,8 @@ define([], function() {
 
         var prop = function(name) { return V.prop(vertex, name, optionalKey, optionalOpts); },
             propRaw = function(name) { return V.propRaw(vertex, name, optionalKey, optionalOpts); },
-            longestProp = function(optionalName) { return V.longestProp(vertex, optionalName); };
+            longestProp = function(optionalName) { return V.longestProp(vertex, optionalName); },
+            props = function (name) { return V.props(vertex, name, optionalKey ); }
 
         try {
 
@@ -24,7 +25,8 @@ define([], function() {
                 prop: prop,
                 dependentProp: prop,
                 propRaw: propRaw,
-                longestProp: longestProp
+                longestProp: longestProp,
+                props: props
             });
 
             if (V.isEdge(vertex)) {

--- a/web/war/src/main/webapp/test/unit/mocks/ontology.json
+++ b/web/war/src/main/webapp/test/unit/mocks/ontology.json
@@ -258,6 +258,15 @@
       }
     },
     {
+      "id": "http://visallo.org/dev#agent",
+      "title": "http://visallo.org/dev#agent",
+      "displayName": "Agent",
+      "titleFormula": "var aliasValues = props('http://visallo.org/dev#alias'); return aliasValues.length.toString();" ,
+      "properties": [
+        "http://visallo.org/dev#alias"
+      ]
+    },
+    {
       "id": "http://visallo.org/dev#phoneCall",
       "title": "http://visallo.org/dev#phoneCall",
       "displayName": "Phone Call",

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -400,11 +400,6 @@ define([
 
                 expect(property).to.be.an('array').that.has.property('length').that.equals(0)
             })
-            it('should throw error if key is passed but is undefined', function() {
-                expect(function() {
-                    V.props(vertexFactory(), PROPERTY_NAME_FIRST, undefined);
-                }).to.throw('Undefined key')
-            })
             it('should not throw error if key is passed is empty string', function() {
                 var vertex = vertexFactory([
                         propertyFactory(PROPERTY_NAME_TITLE, '', 'jason'),

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -7,6 +7,7 @@ define([
         VERTEX_ERROR = 'Vertex is invalid',
         PROPERTY_NAME_ERROR = 'Property name is invalid',
         PROPERTY_NAME_FIRST = 'http://visallo.org/dev#firstName',
+        PROPERTY_NAME_ALIAS = 'http://visallo.org/dev#alias',
         PROPERTY_NAME_LAST = 'http://visallo.org/dev#lastName',
         PROPERTY_NAME_TITLE = 'http://visallo.org#title',
         PROPERTY_NAME_RAW = 'http://visallo.org#raw',
@@ -515,6 +516,16 @@ define([
                     ]);
 
                 V.title(vertex).should.equal('harwig, jason')
+            })
+
+            it('should get a title when title formula uses props', function() {
+                var vertex = vertexFactory([
+                        propertyFactory(PROPERTY_NAME_ALIAS, 'k1', 'jason harwig'),
+                        propertyFactory(PROPERTY_NAME_ALIAS, 'k2', 'jason'),
+                        propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#agent')
+                    ]);
+
+                V.title(vertex).should.equal('2')
             })
 
             it('Concept should be available to formulas for vertices', function() {


### PR DESCRIPTION
As a user, I would like to ability to pick which multi-value property value to display for the title formula by matching a pattern based on the property values.

- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: 
- Add a person entity with 2 title property value of `test` and `test test`
- Go to the admin panel and modify the title formula to be
```
var iri = 'http://visallo.org#title',
    properties = props(iri);
if (properties.length === 0) {
  return '';
}
var test = _.filter(properties, function(p) {return new RegExp("^[a-zA-Z]+$").test(p.value);})
if (test.length > 0) {
    return test[0].value;
} 
return prop(iri) || ‘’;
```  
- the vertex should have the title of `test` and not `test test` on the graph 

Points of Regression: N/A

CHANGELOG
Added: props function to return a list of all matching property values to use in formula evaluator
