### PR TITLE
Add displayType for file size

### DIFF
--- a/config/ontology-minimal/minimal.owl
+++ b/config/ontology-minimal/minimal.owl
@@ -137,6 +137,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <visallo:intent xml:lang="en">media.fileSize</visallo:intent>
         <rdfs:label xml:lang="en">File Size</rdfs:label>
+	<visallo:displayType>bytes</visallo:displayType>
     </owl:DatatypeProperty>
 
     <!-- http://visallo.org/minimal#pageCount -->


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Verify the file size property has a displayType so its easier to read in the UI

Points of Regression: n/a

CHANGELOG
Changed: Updated minimal.owl to have a displayType for file size
