### PR TITLE
Fix timeline blowing up after switching products

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/store/enhancer/observe.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/enhancer/observe.js
@@ -13,14 +13,11 @@ define([], function() {
             let previousState;
 
             const handleChange = () => {
+                const onChange = handler || selector;
                 const newState = handler ? selector(store.getState()) : store.getState();
 
-                if (!handler) {
-                    handler = selector;
-                }
-
                 if (newState !== previousState) {
-                    handler(newState, previousState);
+                    onChange(newState, previousState);
                     previousState = newState;
                 }
             }

--- a/web/war/src/main/webapp/js/fields/histogram/histogram.js
+++ b/web/war/src/main/webapp/js/fields/histogram/histogram.js
@@ -77,11 +77,13 @@ define([
         });
 
         this.watchForProductChanges = function() {
-            this.subscription = visalloData.storePromise.then(store => store.observe(productSelectors.getProduct, (newProduct) => {
-                if (newProduct) {
-                    this.renderChart().then(() => this.updateBarSelection(this.currentSelected));
-                }
-            }));
+            visalloData.storePromise.then(store => {
+                this.subscription = store.observe(productSelectors.getProduct, (newProduct) => {
+                    if (newProduct) {
+                        this.renderChart().then(() => this.updateBarSelection(this.currentSelected));
+                    }
+                });
+            });
         }
 
         this.onFitHistogram = function() {


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Create 3 products: One containing elements with time properties, one containing unauthorized elements, one containing no elements with time properties. Load one > open the timeline > switch between products. The timeline should update correctly

We passed a selector to observe the store but then expected the full state in the handler when waiting for product extended data to load. Switched to use `productSelectors.getElementIdsInProduct` when returning elements to prevent endless loop when checking that all elements had been loaded.

Also fixed an issue with `store.observe` when not passing a selector function it would fail to return the new state after the first change.

no CHANGELOG, no diff since last release
