### PR TITLE
Don't Modify the Vertex when loading TopObjectProperty

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -154,7 +154,7 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
                 Collections.emptyList(),
                 TOP_OBJECT_PROPERTY_IRI,
                 null,
-                true,
+                false,
                 user,
                 PUBLIC
         );


### PR DESCRIPTION
Setting the `isDeclaredInOntology` flag to true causes us to modify the vertex every time code loads the topObjectProperty.

- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
Ensure that the unit tests pass

CHANGELOG
Fixed: topObjectProperty vertex will no longer be updated each time it is loaded
