### PR TITLE
change default sort direction to descending

### DIFF
--- a/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableCard.jsx
+++ b/web/plugins/table/src/main/resources/org/visallo/web/table/js/card/SavedSearchTableCard.jsx
@@ -14,7 +14,7 @@ define([
     const COLUMN_WIDTH = 100;
     const DEFAULT_ROW_NUMBERS = true;
     const DEFAULT_TAB_SETTINGS = {
-        direction: 'ASCENDING',
+        direction: 'DESCENDING',
         sortPropertyIri: '',
         columns: [],
         active: false
@@ -640,13 +640,13 @@ define([
             const { searchId } = this.props.item.configuration;
             const activeTab = _.findKey(tableView, (tab) => tab.active || false);
             let tabSettings = tableView[activeTab];
-            const sortDirection = tabSettings.direction === 'ASCENDING' ? 'DESCENDING' : 'ASCENDING';
             const column = tabSettings.columns.find(({ title }) => title === header);
 
             if (!column.sortPropertyIri) {
                 column.sortPropertyIri = getSortPropertyIri(this.props.properties[header], header);
             }
             const sortPropertyIri = column.sortPropertyIri;
+            const sortDirection = (!tabSettings.sortPropertyIri || tabSettings.direction === 'ASCENDING') ? 'DESCENDING' : 'ASCENDING';
             const isSortable = this.props.properties[sortPropertyIri].sortable !== false;
 
             if (!isSortable) return;

--- a/web/war/src/main/webapp/js/search/sort.js
+++ b/web/war/src/main/webapp/js/search/sort.js
@@ -114,7 +114,7 @@ define([
             if (!hasSort) {
                 this.sortFields.push({
                     field: data.property.title,
-                    direction: 'ASCENDING'
+                    direction: 'DESCENDING'
                 });
                 this.updateSortFields();
             }


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
TEST 1
```
Add a checking account vertex with an amount of 1
Add a checking account vertex with an amount of 2
Search for all checking accounts sorted by amount
```
TEST 2
```
Create a "*" saved search
Add a saved search table to the dashboard
Sort by Amount
```
Both tests should be in descending order of amount

Points of Regression: 
- Search sorting

CHANGELOG
Changed: Default sort direction to be descending