### PR TITLE
remove extra line in example cli tool

### DIFF
--- a/archetype/src/main/resources/archetype-resources/plugins/cli/src/main/java/cli/ExampleCommandLineTool.java
+++ b/archetype/src/main/resources/archetype-resources/plugins/cli/src/main/java/cli/ExampleCommandLineTool.java
@@ -48,7 +48,6 @@ public class ExampleCommandLineTool extends CommandLineTool {
                 }
                 OntologyConstants.PERSON_FULL_NAME_PROPERTY.updateProperty(elemCtx, "Jane Doe", propertyMetadata);
             });
-            OntologyConstants.PERSON_FULL_NAME_PROPERTY.updateProperty(elemCtx, "Jane Doe", propertyMetadata);
 
             // create an edge
             if (!getGraph().doesEdgeExist("v1-to-v2", getAuthorizations())) {


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Run `bin/generate-archetype-project.sh`
- When prompted, `groupId`: `com.visalloexample.helloworld`, `artifactId`: `visallo-helloworld` and everything else should be the default
- cd `visallo-helloworld`
- mvn package

Points of Regression: N/A

NO CHANGELOG
