### PR TITLE
Fix tomcat default http connector

### DIFF
--- a/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
+++ b/web/server/tomcat-server/src/main/java/org/visallo/web/TomcatWebServer.java
@@ -49,10 +49,11 @@ public class TomcatWebServer extends WebServer {
 
         tomcat = new Tomcat();
         tomcat.setPort(super.getHttpPort());
-        tomcat.getService().addConnector(httpsConnector);
 
         Connector defaultConnector = tomcat.getConnector();
         defaultConnector.setRedirectPort(super.getHttpsPort());
+
+        tomcat.getService().addConnector(httpsConnector);
 
         Context context = tomcat.addWebapp(this.getContextPath(), getWebAppDir().getAbsolutePath());
 


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Try to connect to a local instance via both `:8888` and `:8889`. `:8888` should redirect you to `:8889`

no CHANGELOG
