### PR TITLE
fix failed to filter message error when dismissing find paths

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
@@ -573,7 +573,9 @@ public abstract class WorkQueueRepository {
         users.put(userId);
         permissions.put("users", users);
         json.put("permissions", permissions);
-        json.put("data", longRunningProcessQueueItem.get("id"));
+        JSONObject data = new JSONObject();
+        data.put("processId", longRunningProcessQueueItem.get("id"));
+        json.put("data", data);
         broadcastJson(json);
     }
 

--- a/web/war/src/main/webapp/js/data/web-worker/handlers/websocketMessage.js
+++ b/web/war/src/main/webapp/js/data/web-worker/handlers/websocketMessage.js
@@ -108,11 +108,11 @@ define([
                     })
                 }
             },
-            longRunningProcessDeleted: function(processId) {
+            longRunningProcessDeleted: function(data) {
                 dispatchMain('rebroadcastEvent', {
                     eventName: 'longRunningProcessDeleted',
                     data: {
-                        processId: processId
+                        processId: data.processId
                     }
                 });
             },


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Create 3 entities, A, B, & C
- Create edges from A->B, B->C
- Find path between A->C
- Leave the Activity panel open and find path between A & C again and immediately dismiss the first one found while the new one is still processing

Points of Regression: N/A

CHANGELOG
Fixed: Activity pane retaining dismissed find path processes
