### PR TITLE
Fix edge inspector with unauthorized vertices

### DIFF
--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -1196,7 +1196,7 @@ define([
             isEdge: function(vertex) { return vertex && vertex.type && vertex.type === 'edge'; },
 
             isExtendedDataRow: function(item) {
-                return (item.id && item.id.rowId) || (item.type === 'extendedDataRow');
+                return item && ((item.id && item.id.rowId) || (item.type === 'extendedDataRow'));
             },
 
             isArtifact: function(vertex) {


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Create 2 entities and an edge between them. Hide one or both vertices with an authorization. Open the edge in the element inspector.

no CHANGELOG
