### PR TITLE
Add a non-block in-memory workqueueRepository.

### DIFF
--- a/core/plugins/model-queue-inmemory/src/main/java/org/visallo/model/queue/inmemory/NonBlockInMemoryWorkQueueRepository.java
+++ b/core/plugins/model-queue-inmemory/src/main/java/org/visallo/model/queue/inmemory/NonBlockInMemoryWorkQueueRepository.java
@@ -1,0 +1,123 @@
+package org.visallo.model.queue.inmemory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.json.JSONObject;
+import org.vertexium.Graph;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.ingest.WorkerSpout;
+import org.visallo.core.ingest.WorkerTuple;
+import org.visallo.core.model.WorkQueueNames;
+import org.visallo.core.model.workQueue.Priority;
+import org.visallo.core.model.workQueue.WorkQueueRepository;
+
+import java.util.*;
+
+/**
+ * To use it,change the config in config/visallo.properties
+ *
+ * repository.workQueue=org.visallo.model.queue.inmemory.NonBlockInMemoryWorkQueueRepository
+ */
+
+@Singleton
+public class NonBlockInMemoryWorkQueueRepository extends WorkQueueRepository {
+
+  private static Map<String, Deque<byte[]>> queues = new ConcurrentHashMap<>();
+  private List<BroadcastConsumer> broadcastConsumers = new ArrayList<>();
+  private ExecutorService executor = Executors.newFixedThreadPool(10);
+
+  @Inject
+  public NonBlockInMemoryWorkQueueRepository(
+      Graph graph,
+      WorkQueueNames workQueueNames,
+      Configuration configuration
+  ) {
+    super(graph, workQueueNames, configuration);
+
+  }
+
+  /**
+   * make the job run background, so the api call may return more faster.
+   */
+
+  @Override
+  protected void broadcastJson(JSONObject json) {
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        for (BroadcastConsumer consumer : broadcastConsumers) {
+          consumer.broadcastReceived(json);
+        }
+
+      }
+    });
+
+  }
+
+  @Override
+  public void pushOnQueue(String queueName, byte[] data, Priority priority) {
+    LOGGER.debug("push on queue: %s: %s", queueName, data);
+    addToQueue(queueName, data, priority);
+  }
+
+  public void addToQueue(String queueName, byte[] data, Priority priority) {
+    final Deque<byte[]> queue = getQueue(queueName);
+    if (priority == Priority.HIGH) {
+      queue.addFirst(data);// add to head
+    } else {
+      queue.add(data); // add to tail
+    }
+  }
+
+  @Override
+  public void flush() {
+
+  }
+
+  @Override
+  public void format() {
+    clearQueue();
+  }
+
+  @Override
+  public void subscribeToBroadcastMessages(BroadcastConsumer broadcastConsumer) {
+    broadcastConsumers.add(broadcastConsumer);
+  }
+
+  @Override
+  public WorkerSpout createWorkerSpout(String queueName) {
+    final Deque<byte[]> queue = getQueue(queueName);
+    return new WorkerSpout() {
+      @Override
+      public WorkerTuple nextTuple() throws Exception {
+        if (queue.isEmpty()) {
+          return null;
+        }
+        byte[] entry = queue.pollFirst();
+        if (entry == null) {
+          return null;
+        }
+        return new WorkerTuple("", entry);
+
+      }
+    };
+  }
+
+  public static void clearQueue() {
+    queues.clear();
+  }
+
+  @Override
+  protected void deleteQueue(String queueName) {
+    queues.remove(queueName);
+  }
+
+  public static Deque<byte[]> getQueue(String queueName) {
+    return queues.computeIfAbsent(queueName, k -> new ConcurrentLinkedDeque<>());
+  }
+}


### PR DESCRIPTION
- [ ] Add a non-block in-memory workqueueRepository.

Testing Instructions:

I don't have a unit test for the source code don't hava test packages .
And I don't want to change the project structure.

Points of Regression:

CHANGELOG
Added: 
  - org.visallo.model.queue.inmemory.NonBlockInMemoryWorkQueueRepository

## The problem to solve

I find the rest-api-call looks so slow..  Here is the log .
```[webster.App.ACCESS_LOG] POST /edge/create 61456ms
[webster.App.ACCESS_LOG] POST /edge/create 122897ms
[webster.App.ACCESS_LOG] POST /edge/create 8006ms
[webster.App.ACCESS_LOG] POST /edge/create 6005ms
[webster.App.ACCESS_LOG] POST /edge/create 17216ms
[webster.App.ACCESS_LOG] POST /edge/create 31725ms
[webster.App.ACCESS_LOG] POST /edge/create 13411ms
[webster.App.ACCESS_LOG] POST /edge/create 13110ms
....
```

I rewite the workqueueRepository .
It looks faster . Here is the log file.
```
[webster.App.ACCESS_LOG] POST /edge/create 666ms
[webster.App.ACCESS_LOG] POST /edge/create 816ms
[webster.App.ACCESS_LOG] POST /edge/create 562ms
[webster.App.ACCESS_LOG] POST /edge/create 734ms
[webster.App.ACCESS_LOG] POST /edge/create 752ms
[webster.App.ACCESS_LOG] POST /edge/create 623ms
......
```


Changed: 
  NO CHANGES

Documentation: 
  
Deprecated:
  -   NO DEPRECATED

Removed:
 - NO REMOVED

Fixed:
 - NO FIXED

Security:
 - NO SECURITY