### PR TITLE
Block entirely empty compound property form submission

### DIFF
--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/layers/MapLayerItem.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/layers/MapLayerItem.jsx
@@ -11,7 +11,7 @@ define([
 
     const MapLayerItem = ({ layer, config, style, toggleable, onToggleLayer }) => {
         const layerStatus = layer.get('status');
-        const statusMessage = _.isObject(layerStatus) && layerStatus.message;
+        const statusMessage = (_.isObject(layerStatus) && layerStatus.message) || null;
         const hasError = _.isObject(layerStatus) && layerStatus.type === 'error';
         const visible = config && config.visible !== undefined ? config.visible : layer.getVisible();
 
@@ -26,7 +26,7 @@ define([
                 />
                 <div className="layer-title">
                     <div className="title">{ titleRenderer(layer) }</div>
-                    <span className="subtitle" title={statusMessage}>{ statusMessage || null }</span>
+                    <span className="subtitle" title={statusMessage}>{ statusMessage }</span>
                 </div>
                 <div
                     className="layer-icon drag-handle"

--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -482,6 +482,8 @@ define([
             var self = this;
 
             this.justification = data;
+
+            this.modified.justification = data.valid && (data.justificationText || data.sourceInfo);
             this.checkValid();
         };
 

--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -1068,6 +1068,7 @@ define([
                 if (values.length) {
                     var properties = [];
                     if (dependentIris) {
+                        var hasValue = false;
                         dependentIris.forEach(function(iri, i) {
                             var property = _.findWhere(vertex.properties, {
                                     name: iri,
@@ -1087,8 +1088,17 @@ define([
                                     value: value
                                 };
                             }
+                            hasValue = hasValue || (
+                                property.value !== undefined
+                                && property.value !== ''
+                                && property.value !== null
+                            );
                             properties.push(property);
                         })
+
+                        if (!hasValue) {
+                            return false
+                        }
                     }
                     vertex = _.extend({}, vertex, { properties: properties });
                 }

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -598,6 +598,18 @@ define([
                 expect(V.propValid(vertex, [['override last name'], ['first']], COMPOUND_PROPERTY_NAME)).to.be.true
             })
 
+            it('should validate with at least one overriding value', function() {
+                var vertex = vertexFactory([
+                    propertyFactory(PROPERTY_NAME_GEO_AND_DATE_DATE, 'k1', Date.UTC(2017, 12, 1)),
+                    propertyFactory(PROPERTY_NAME_GEO_AND_DATE_GEO, 'k1', { latitude: 1, longitude: 1 }),
+                    propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
+                ]);
+
+                expect(V.propValid(vertex, ['', ''], PROPERTY_NAME_GEO_AND_DATE, 'k1')).to.be.false
+                expect(V.propValid(vertex, [undefined, Date.UTC(2017, 12, 1)], PROPERTY_NAME_GEO_AND_DATE, 'k1')).to.be.true
+                expect(V.propValid(vertex, [{ latitude: 1, longitude: 1 }, undefined], PROPERTY_NAME_GEO_AND_DATE, 'k1')).to.be.true
+            })
+
             it('should not modify vertex', function() {
                 var vertex = vertexFactory([
                         propertyFactory(PROPERTY_NAME_FIRST, 'k1', 'jason'),


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions: Try to save a compound property with empty value fields. Try to update an existing property with only a justification change.

Points of Regression: Any property form submissions.

Also fixed:
- Updating with only a new justification
- console warning with title attribute in MapLayerItem

no CHANGELOG, no diff since last release
