### PR TITLE
Return Total Hits with Search Results (4.0)

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexiumObjectSearchBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexiumObjectSearchBase.java
@@ -123,6 +123,7 @@ public abstract class VertexiumObjectSearchBase {
             VertexiumObjectSearchRunnerBase.QueryAndData queryAndData,
             QueryResultsIterable<? extends VertexiumObject> searchResults
     ) {
+        results.setTotalHits(searchResults.getTotalHits());
         if (searchResults instanceof IterableWithSearchTime) {
             results.setSearchTime(((IterableWithSearchTime) searchResults).getSearchTimeNanoSeconds());
         }


### PR DESCRIPTION
When upgrading to vertexium, we accidentally stopped sending the total hits to the UI with search results in this PR: https://github.com/visallo/visallo/pull/1494

- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Run a search and ensure that the UI displays the proper number of search results.
