### PR TITLE
Add cutoff configuration to extracted text

### DIFF
--- a/web/war/src/main/webapp/js/detail/text/text.js
+++ b/web/war/src/main/webapp/js/detail/text/text.js
@@ -503,7 +503,7 @@ define([
                     .then(function(artifactText) {
                         var html = self.processArtifactText(artifactText);
                         if (expand) {
-                            $section.find('.text').html(html);
+                            $section.find('.text')[0].innerHTML = html;
                         }
                     });
             }

--- a/web/war/src/main/webapp/less/detail/detail.less
+++ b/web/war/src/main/webapp/less/detail/detail.less
@@ -329,6 +329,17 @@
         .underneath {
           padding: 0;
         }
+        .truncated {
+          .disable-text-selection;
+          font-style: italic;
+          margin: 1em 0 0 0;
+          text-align: center;
+          color: #5f5f5f;
+          background: #ffff002e;
+          border-radius: 3px;
+          padding: 0.5em;
+          border: 1px solid #cece31;
+        }
       }
     }
   }

--- a/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
@@ -22,6 +22,7 @@ public class WebConfiguration {
     public static final String VERTEX_RELATIONSHIPS_MAX_PER_SECTION = PREFIX + "vertex.relationships.maxPerSection";
     public static final String DETAIL_HISTORY_STACK_MAX = PREFIX + "detail.history.stack.max";
     public static final String MAX_SELECTION_PARAGRAPHS_FOR_TERM_POPOVER = PREFIX + "detail.text.popover.maxSelectionParagraphs";
+    public static final String MAX_TEXT_LENGTH = PREFIX + "detail.text.maxTextLength";
     public static final String FIELD_JUSTIFICATION_VALIDATION = PREFIX + "field.justification.validation";
     public static final String SEARCH_DISABLE_WILDCARD_SEARCH = PREFIX + "search.disableWildcardSearch";
     public static final String SEARCH_EXACT_MATCH = PREFIX + "search.exactMatch";
@@ -105,6 +106,7 @@ public class WebConfiguration {
         DEFAULTS.put(DETAIL_HISTORY_STACK_MAX, "5");
 
         DEFAULTS.put(MAX_SELECTION_PARAGRAPHS_FOR_TERM_POPOVER, "5");
+        DEFAULTS.put(MAX_TEXT_LENGTH, "1500000");
 
         DEFAULTS.put(Configuration.VIDEO_PREVIEW_FRAMES_COUNT, Integer.toString(ArtifactThumbnailRepository.DEFAULT_FRAMES_PER_PREVIEW));
 


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

<img width="267" alt="screen shot 2017-12-12 at 5 13 01 pm" src="https://user-images.githubusercontent.com/7098/33913519-cc4b2b8a-df5f-11e7-82bf-94e86c1caf61.png">

added new configuration to limit the text extraction result. It's not exact because it closes when it can (no opening tags.)

Testing Instructions: Upload text doc larger than ~1MB, should see truncated text at bottom.

Points of Regression:

CHANGELOG
Added: Configuration to adjust the max length hint for extracted text. `web.ui.detail.text.maxTextLength`. Previously very large documents could crash the browser. Defaults to length of 1.5 million.
