### PR TITLE
Search filter menu disappearing (4.0)

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filtersTpl.hbs
+++ b/web/war/src/main/webapp/js/search/filters/filtersTpl.hbs
@@ -1,6 +1,6 @@
 <ul class="nav nav-list search-options" {{#unless showMatchType}}style="display:none"{{/unless}}>
   <li class="nav-header"><span>Match</span>
-    <div class="match-types" style="float:right">
+    <div class="match-types">
       <label><input type="radio" class="match-type-vertex" name="match-type" 
         {{#if showConceptFilter}}checked{{/if}} value="vertex">{{ i18n 'search.filters.match.vertex' }}</label>
       <label><input type="radio" class="match-type-edge" name="match-type" 

--- a/web/war/src/main/webapp/less/search/search.less
+++ b/web/war/src/main/webapp/less/search/search.less
@@ -691,16 +691,10 @@ width: 215px;
 .search-options {
   overflow: hidden;
 
-  li.nav-header {
-    display: flex;
-    flex-wrap: wrap;
-  }
   span {
-      flex: auto;
       margin-right: 1em;
   }
   div {
-    white-space: nowrap;
     label {
       margin-right: 1em;
       display: inline;


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Move match selection to next line so scrollbar appearance doesn't move it down and break typahead field click. Need to redesign, but this will work as even when search pane is smallest the match types won't wrap

CHANGELOG
Fixed: Search filter typeahead menus disappearing on click because of scrollbar.
