### PR TITLE
Graph layout spacing (4.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -36,15 +36,20 @@ define([
     });
     const LAYOUT_OPTIONS = {
         // Customize layout options
-        random: { padding: 10 },
+        circle: {
+            nodeDimensionsIncludeLabels: true
+        },
+        bettergrid: {},
         cose: {
+            nodeDimensionsIncludeLabels: true,
             animate: function(els) {
                 return els.length < MAX_ELEMENTS_BEFORE_NO_ANIMATE_LAYOUT;
             },
             edgeElasticity: 10
         },
         dagre: {
-
+            nodeDimensionsIncludeLabels: true,
+            spacingFactor: 1.3
         }
     };
     const PREVIEW_DEBOUNCE_SECONDS = 3;
@@ -474,6 +479,9 @@ define([
             var opts = {
                 name: layout,
                 fit: false,
+                animate: true,
+                animationDuration: 250,
+                animationEasing: 'ease-in-out-quad',
                 stop: () => {
                     this.layoutDone = true;
                     if (!onlySelected) {

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/betterGrid.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/betterGrid.js
@@ -1,10 +1,11 @@
 define([], function() {
     'use strict';
 
-    function BetterGrid(options) {
-        this.spaceX = options && options.spaceX || 390;
-        this.spaceY = options && options.spaceY || 150;
-        this.options = options;
+    function BetterGrid(options = {}) {
+        const { spaceX = 300, spaceY = 100, ...rest } = options;
+        this.spaceX = spaceX * devicePixelRatio;
+        this.spaceY = spaceY * devicePixelRatio;
+        this.options = rest;
     }
 
     BetterGrid.prototype.run = function() {

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/createConnectionPopover.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/createConnectionPopover.js
@@ -132,7 +132,7 @@ define([
 
             var node = this.nodes[this.currentNodeIndex % 2],
                 other = this.nodes[(this.currentNodeIndex + 1) % 2],
-                otherTitle = other.data('truncatedTitle'),
+                otherTitle = other.data('title'),
                 currentNodePosition = node.renderedPosition(),
                 otherNodePosition = other.renderedPosition();
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/createConnectionPopoverTpl.ejs
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/createConnectionPopoverTpl.ejs
@@ -1,7 +1,7 @@
 <div class="popover connect-dialog top">
   <div class="popover-title">
     <button class="btn btn-link invert-connection">Invert</button>
-    <span class="title"><%= cy.getElementById(edge.data('source')).data('truncatedTitle') %></span>
+    <span class="title"><%= cy.getElementById(edge.data('source')).data('title') %></span>
   </div>
   <div class="arrow"></div>
   <div class="popover-content">

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/styles.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/styles.js
@@ -148,6 +148,8 @@ define([], function() {
                         'text-outline-width': 2,
                         'text-halign': 'center',
                         'text-valign': 'bottom',
+                        'text-max-width': 200 * pixelRatio,
+                        'text-wrap': 'ellipsis',
                         content: 'Loading…',
                         opacity: 1,
                         color: '#999',
@@ -202,7 +204,7 @@ define([], function() {
                     css: {
                         'background-color': '#fff',
                         'background-image': 'data(imageSrc)',
-                        content: 'data(truncatedTitle)',
+                        content: 'data(title)',
                     }
                 },
                 {
@@ -211,7 +213,14 @@ define([], function() {
                         'background-color': '#fff',
                         'background-image': 'data(imageSrc)',
                         shape: 'rectangle',
-                        content: 'data(truncatedTitle)',
+                        content: 'data(title)',
+                    }
+                },
+                {
+                    selector: 'node.fullTitle',
+                    css: {
+                        'text-wrap': 'wrap',
+                        'text-max-width': 300 * pixelRatio
                     }
                 },
                 {

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/snap.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/snap.js
@@ -1,6 +1,6 @@
 define([], function() {
-    const GRAPH_SNAP_TO_GRID = 175;
-    const GRAPH_SNAP_TO_GRID_Y = 75;
+    const GRAPH_SNAP_TO_GRID = 300;
+    const GRAPH_SNAP_TO_GRID_Y = 100;
     const GRAPH_NODE_HEIGHT = 100;
 
     return snapPosition;


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

* Fix dagre configuration to include labels
* Animate all layouts
* Fix grid layout differences based on pixelRatio
* Change title truncation to use built-in cytoscape truncating instead
of 3 words. Will now wrap to multiple lines instead of long one line.
  * Tested on collapsed nodes also
* Tested all layouts on pixelRatio=1 & 2 devices give same or very
similar results
* Adjust snap to grid numbers to match grid layout

Testing Instructions: Test graph layouts on browser on hi-dpi monitors and low. Test title truncation/hovering shows wrapped title

Points of Regression: Graph may show less of a title, it's based on width, where before was 3 words.

NO CHANGELOG because the layouts spacing was off in between releases
