### PR TITLE
pass all property metadata to the front end for video transcripts (4.0)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
+++ b/core/core/src/main/java/org/visallo/core/util/ClientApiConverter.java
@@ -212,14 +212,10 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
             SandboxStatus sandboxStatus = sandboxStatuses[i];
             VideoFrameInfo videoFrameInfo;
             if ((videoFrameInfo = VideoPropertyHelper.getVideoFrameInfoFromProperty(property)) != null) {
-                String textDescription = VisalloProperties.TEXT_DESCRIPTION_METADATA.getMetadataValueOrDefault(
-                        property.getMetadata(),
-                        null
-                );
                 addVideoFramePropertyToResults(
                         clientApiProperties,
                         videoFrameInfo.getPropertyKey(),
-                        textDescription,
+                        property.getMetadata(),
                         sandboxStatus
                 );
             } else {
@@ -253,7 +249,7 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
     private static void addVideoFramePropertyToResults(
             List<ClientApiProperty> clientApiProperties,
             String propertyKey,
-            String textDescription,
+            Metadata metadata,
             SandboxStatus sandboxStatus
     ) {
         ClientApiProperty clientApiProperty = findProperty(
@@ -266,10 +262,9 @@ public class ClientApiConverter extends org.visallo.web.clientapi.util.ClientApi
             clientApiProperty.setKey(propertyKey);
             clientApiProperty.setName(MediaVisalloProperties.VIDEO_TRANSCRIPT.getPropertyName());
             clientApiProperty.setSandboxStatus(sandboxStatus);
-            clientApiProperty.getMetadata().put(
-                    VisalloProperties.TEXT_DESCRIPTION_METADATA.getMetadataKey(),
-                    textDescription
-            );
+            for (Metadata.Entry entry : metadata.entrySet()) {
+                clientApiProperty.getMetadata().put(entry.getKey(), toClientApiValue(entry.getValue()));
+            }
             clientApiProperty.setStreamingPropertyValue(true);
             clientApiProperties.add(clientApiProperty);
         }


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Make sure transcripts have all "default" metadata

Points of Regression: N/A

CHANGELOG
Fixed: Transcripts Properties not passing all metadata to the UI
