### PR TITLE
Fix drag +drop in IE 4.0

### DIFF
--- a/web/war/src/main/webapp/js/detail/text/text.js
+++ b/web/war/src/main/webapp/js/detail/text/text.js
@@ -916,14 +916,16 @@ define([
                         concept = type && self.concepts.byId[type];
 
                     if (concept) {
-                        this.classList.forEach(className => {
-                            if (className.indexOf('conceptId-') === 0 && className !== concept.className) {
-                                this.classList.remove(className);
-                            }
+                        const classes = this.className.split(' ').filter(className => {
+                            return !(className.indexOf('conceptId-') === 0 && className !== concept.className)
                         });
-                        if (!this.classList.contains(concept.className)) {
-                            this.classList.add(concept.className);
+
+                        if (!(concept.className in classes)) {
+                            classes.push(concept.className);
+                            this.className = classes.join(' ');
                             self.loadSelectorForConcept(concept);
+                        } else {
+                            this.className = classes.join(' ');
                         }
                     }
                 })

--- a/web/war/src/main/webapp/less/util/popovers/detailTextPopover.less
+++ b/web/war/src/main/webapp/less/util/popovers/detailTextPopover.less
@@ -47,7 +47,7 @@
             }
           }
           > section {
-            flex: 1 1 auto;
+            flex: 1 1 100%;
           }
 
           &.suggestion {


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Drag a document into Visallo, then try to drag other items to different places (e.g. inspector edge items, search results, resolved terms), then refresh and test in the reverse order. They should all work.

Also fixed: 
- Unbounded resolved popover width with large text selection.
- In IE, resolved terms with underline colors defined by the ontology were not getting applied.


CHANGELOG
Fixed: In IE, if dragging a document into the browser was the first thing you did dragging elements within the page would not work afterwards and vice versa.
