### PR TITLE
Fix tinted concept icons not appearing in edge list items (4.0)

### DIFF
--- a/web/war/src/main/webapp/js/util/element/edge-item.hbs
+++ b/web/war/src/main/webapp/js/util/element/edge-item.hbs
@@ -3,7 +3,7 @@
   <div class="vertex-in">{{ inVertex.title }}</div>
 </div>
 <div class="info">
-  <div class="edge-vertex-preview{{#if outVertex.custom}} custom{{/if}}" style="background-image: url({{ outVertex.image }});"/>
+  <div class="edge-vertex-preview{{#if outVertex.custom}} custom{{/if}}" style="background-image: url('{{ outVertex.image }}');"/>
   <span class="title">
     <span class="rel_title">{{ title }}</span>
     <div>
@@ -11,5 +11,5 @@
       <span class="source">{{#if subtitle }}{{ subtitle }}{{/if}}</span>
     </div>
   </span>
-  <div class="edge-vertex-preview{{#if inVertex.custom}} custom{{/if}}" style="background-image: url({{ inVertex.image }});"/>
+  <div class="edge-vertex-preview{{#if inVertex.custom}} custom{{/if}}" style="background-image: url('{{ inVertex.image }}');"/>
 </div>


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Add quotes to edge item background-image url. Quotation-less url's are parsed differently and more characters need to be escaped, which we ran into with parentheses when specifying an rgb() tint value

Testing Instructions: View edges in a list (e.g. search results). Tinted concept icons should be visible

no CHANGELOG
