### PR TITLE
Select relationships inside collapsed nodes (4.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -391,44 +391,6 @@ define([
             this.props.onCollapseSelectedNodes(selectedNodes);
         },
 
-        onMenuSelect(select) {
-            const { cy } = this.state;
-
-            var nodes = cy.nodes();
-            var edges = cy.edges();
-            var selectedVertices = nodes.filter(':selected');
-            var unselectedVertices = nodes.filter(':unselected');
-            var selectedEdges = edges.filter(':selected');
-            var unselectedEdges = edges.filter(':unselected');
-
-            switch (select) {
-                case 'all':
-                    unselectedEdges.select();
-                    unselectedVertices.select();
-                    break;
-                case 'none':
-                    selectedVertices.unselect();
-                    selectedEdges.unselect();
-                    break;
-                case 'invert':
-                    selectedVertices.unselect();
-                    selectedEdges.unselect();
-                    unselectedVertices.select();
-                    unselectedEdges.select();
-                    break;
-                case 'vertices':
-                    selectedEdges.unselect();
-                    unselectedVertices.select();
-                    break;
-                case 'edges':
-                    selectedVertices.unselect();
-                    unselectedEdges.select();
-                    break;
-                default:
-                    this.props.onMenuSelect(select);
-            }
-        },
-
         onMenuLayout(layout, options) {
             const { cy } = this.state;
             const onlySelected = options && options.onlySelected;


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

* Moved context menu selection handlers from Cytoscape.jsx to Graph.jsx
* Instead of using cytoscape calls to modify the selection get the ids from redux and dispatch setSelection actions directly, otherwise we miss elements that are in the graph product but not rendered on the graph such as edges between vertices inside of a collapsed node. 
* Select edges as well as vertices inside of collapsed nodes when clicking on collapsed nodes.

Points of Regression: context menu selection actions on the graph

CHANGELOG
Changed: Relationships between collapsed entities on the graph are now selected when clicking on the collapsed group and when choosing to select all relationships from the context menu.
