### PR TITLE
Truncate graph title strings (4.0)

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -500,6 +500,10 @@ contextmenu.blocked=Detected blocked context menu. Alt+Click for contextual menu
 vertex.status.unpublished=unpublished
 vertex.property.not_available=No {0} available
 vertex.property.title.not_available=No title available
+vertex.titles.none=0 entities
+vertex.titles.other=and {0} other
+vertex.titles.others=and {0} others
+vertex.titles.oxford=and {0}
 
 element.list.in_graph=Graph
 element.list.in_graph.tooltip=Displayed in Graph

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -31,6 +31,7 @@ define([
     const MaxPathsToFocus = 100;
     const MaxPreviewPopovers = 5;
     const MaxEdgesBetween = 5;
+    const MaxTitleWords = 15;
     const REQUEST_UPDATE_DEBOUNCE = 300;
     const FORCE_UPDATE_DEBOUNCE = 1000;
 
@@ -1613,10 +1614,14 @@ define([
 
         let title;
         if (vertices) {
-            if (byType.vertex && byType.vertex.length > 1) {
-                title = byType.vertex.map(({ id }) => (
-                    vertices[id] ? F.vertex.title(vertices[id]) : ''
-                )).join(', ');
+            const { vertex } = byType;
+            if (vertex && vertex.length > 1) {
+                title = F.vertex.titles(vertex.reduce(function(list, { id }) {
+                    if (vertices[id]) {
+                        list.push(vertices[id])
+                    }
+                    return list;
+                }, []), { maxBeforeOther: 3, maxTitleWords: 3 })
             } else {
                 title = i18n('org.visallo.web.product.graph.collapsedNode.entities.singular');
             }
@@ -1627,7 +1632,7 @@ define([
 
     const vertexToCyNode = (vertex, transformers) => {
         return memoizeFor('vertexToCyNode', vertex, function() {
-            const title = F.vertex.title(vertex);
+            const title = F.string.truncate(F.vertex.title(vertex), MaxTitleWords);
             const conceptType = F.vertex.prop(vertex, 'conceptType');
             const imageSrc = F.vertex.image(vertex, null, 150);
             const selectedImageSrc = F.vertex.selectedImage(vertex, null, 150);

--- a/web/war/src/main/webapp/js/util/formatters.js
+++ b/web/war/src/main/webapp/js/util/formatters.js
@@ -579,13 +579,14 @@ define([
                     string = $.trim(str),
                     wordsArray = string.split(/\s+/),
                     truncated = wordsArray.slice(0, words).join(' '),
-                    ellipsis = '…';
+                    ellipsis = '…',
+                    replacePunctuation = str => str.replace(/[,;:?.!]+$/, '');
 
                 if (truncated.length > maxChars) {
                     // Use standard truncation (set amount of characters)
-                    truncated = string.substring(0, maxChars) + ellipsis;
+                    truncated = replacePunctuation(string.substring(0, maxChars)) + ellipsis;
                 } else if (truncated !== string.replace(/\s+/g, ' ')) {
-                    truncated = truncated + ellipsis;
+                    truncated = replacePunctuation(truncated) + ellipsis;
                 }
 
                 return truncated

--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -1108,6 +1108,39 @@ define([
                 return Boolean(result);
             },
 
+            titles: function(vertices, { maxBeforeOther = 3, maxTitleWords = 4 } = {}) {
+                if (!_.isArray(vertices)) throw new Error('Must pass an array of vertices: ' + typeof vertices)
+
+                const { length } = vertices;
+
+                if (length === 0) {
+                    return i18n('vertex.titles.none');
+                }
+                if (length === 1) {
+                    return V.title(vertices[0])
+                }
+
+                const titles = vertices.slice(0, Math.min(length, maxBeforeOther))
+                    .map((vertex, i) => {
+                        const title = maxTitleWords > 0 ?
+                            (F.string.truncate(V.title(vertex) || '', maxTitleWords)) : V.title(vertex);
+
+                        if (i === length - 1) {
+                            return i18n('vertex.titles.oxford', title)
+                        }
+                        return title;
+                    })
+                    .join(', ')
+
+                if (maxBeforeOther > 0 && length > maxBeforeOther) {
+                    const diff = length - maxBeforeOther;
+                    const others = i18n('vertex.titles.other' + (diff > 1 ? 's' : ''), diff);
+                    return `${titles}, ${others}`
+                }
+
+                return titles;
+            },
+
             /**
              * Get the `title` of the element, using order:
              *

--- a/web/war/src/main/webapp/test/unit/mocks/messages.js
+++ b/web/war/src/main/webapp/test/unit/mocks/messages.js
@@ -2,7 +2,5 @@
 define([], function() {
     'use strict';
 
-    return function(key) {
-        return key;
-    }
+    return i18n;
 });

--- a/web/war/src/main/webapp/test/unit/runner/testRunner.js
+++ b/web/war/src/main/webapp/test/unit/runner/testRunner.js
@@ -15,8 +15,14 @@ requirejs.config({
     //console.log(map.name)
 //}
 
-global.visalloEnvironment = { dev: false, prod: true };
+Object.defineProperty(global, 'i18n', {
+    value: function i18nMocked(key, ...args) {
+        return args.length ? `${key}(${args.join(',')})` : key;
+    },
+    writable: false
+});
 
+global.visalloEnvironment = { dev: false, prod: true };
 
 requirejs(['/base/jsc/require.config.js'], function(cfg) {
 
@@ -139,10 +145,6 @@ requirejs(['/base/jsc/require.config.js'], function(cfg) {
                 // Globals for assertions
                 assert = chai.assert;
                 expect = chai.expect;
-
-                i18n = function(key) {
-                    return key;
-                };
 
                 // Use the twitter flight interface to mocha
                 mocha.ui('mocha-flight');

--- a/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
@@ -138,6 +138,13 @@ define([
                 f.string.palantirPrettyPrint('joHn wiLKes-booTh').should.equal('John Wilkes-Booth')
                 f.string.palantirPrettyPrint('monty-burns').should.equal('Monty-Burns')
             })
+
+            it('should truncate', function() {
+                f.string.truncate('one two, 3 and four. Another sentence', 4).should.equal('one two, 3 and…')
+                f.string.truncate('one two, 3 and four. Another sentence', 2).should.equal('one two…')
+                f.string.truncate('one two, 3 and four. Another sentence', 5).should.equal('one two, 3 and four…')
+                f.string.truncate('one two, 3 and four. Another sentence? Third', 7).should.equal('one two, 3 and four. Another sentence…')
+            })
         })
 
         describe('for geoLocations', function() {

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -513,6 +513,53 @@ define([
             })
         })
 
+        describe('titles', function() {
+            it('should throw when not an array', function() {
+                expect(() => V.titles()).to.throw('array')
+                expect(() => V.titles('')).to.throw('array')
+                expect(() => V.titles({})).to.throw('array')
+            })
+
+            it('should return none', function() {
+                V.titles([]).should.be.equal('vertex.titles.none')
+            })
+
+            it('should return first', function() {
+                var vertex = vertexFactory([
+                        propertyFactory(PROPERTY_NAME_FIRST, 'k1', 'jason'),
+                        propertyFactory(PROPERTY_NAME_LAST, 'k1', 'harwig'),
+                        propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
+                    ]);
+                V.titles([vertex]).should.be.equal('harwig, jason')
+            })
+
+            it('should return up to option', function() {
+                var v1 = vertexFactory([
+                        propertyFactory(PROPERTY_NAME_FIRST, 'k1', 'jason'),
+                        propertyFactory(PROPERTY_NAME_LAST, 'k1', 'harwig'),
+                        propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
+                    ]);
+                var v2 = vertexFactory([
+                        propertyFactory(PROPERTY_NAME_FIRST, 'k1', 'jeff'),
+                        propertyFactory(PROPERTY_NAME_LAST, 'k1', 'kunkle'),
+                        propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
+                    ]);
+                var v3 = vertexFactory([
+                        propertyFactory(PROPERTY_NAME_FIRST, 'k1', 'joan'),
+                        propertyFactory(PROPERTY_NAME_LAST, 'k1', 'smith'),
+                        propertyFactory(PROPERTY_NAME_CONCEPT, 'http://visallo.org/dev#person')
+                    ]);
+                V.titles([v1, v2, v3], { maxBeforeOther: 1, maxTitleWords: 1 })
+                    .should.be.equal('harwig…, vertex.titles.others(2)')
+
+                V.titles([v1, v2, v3], { maxBeforeOther: 2, maxTitleWords: 2 })
+                    .should.be.equal('harwig, jason, kunkle, jeff, vertex.titles.other(1)')
+
+                V.titles([v1, v2, v3], { maxBeforeOther: 3, maxTitleWords: 1 })
+                    .should.be.equal('harwig…, kunkle…, vertex.titles.oxford(smith…)')
+            })
+        })
+
         describe('title', function() {
             it('should get a title even if it refers to compound property', function() {
                 var vertex = vertexFactory([


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

We still truncate by default, but now on hover it will still truncate:
1) If an entity, no more than 20 words
2) If collapsed, comma separate the titles, unless more than 3, then add
", and n others"

![hover-collapsed](https://user-images.githubusercontent.com/7098/34274726-7e90c092-e65f-11e7-9316-fc20f8b251fe.png)

Testing Instructions: Try with long titles in entities and in collapsed nodes

NO CHANGELOG

already a changelog for title hovering changed