### PR TITLE
Add session count to admin user list

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/user/UserRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/UserRepository.java
@@ -164,15 +164,21 @@ public abstract class UserRepository {
     }
 
     public ClientApiUser toClientApi(User user) {
-        return toClientApi(user, null);
+        return toClientApi(user, null, null);
     }
 
-    private ClientApiUser toClientApi(User user, Map<String, String> workspaceNames) {
+    private ClientApiUser toClientApi(User user, Map<String, String> workspaceNames, Map<String, Integer> sessionCounts) {
         ClientApiUser u = new ClientApiUser();
         u.setId(user.getUserId());
         u.setUserName(user.getUsername());
         u.setDisplayName(user.getDisplayName());
         u.setStatus(user.getUserStatus());
+        if (sessionCounts != null) {
+            Integer count = sessionCounts.get(user.getUserId());
+            if (count != null) {
+                u.setSessionCount(count);
+            }
+        }
         u.setUserType(user.getUserType());
         u.setEmail(user.getEmailAddress());
         u.setCurrentLoginDate(user.getCurrentLoginDate());
@@ -186,14 +192,19 @@ public abstract class UserRepository {
         return u;
     }
 
+
     protected String formatUsername(String username) {
         return username.trim().toLowerCase();
     }
 
     public ClientApiUsers toClientApi(Iterable<User> users, Map<String, String> workspaceNames) {
+        return toClientApi(users, workspaceNames, null);
+    }
+
+    public ClientApiUsers toClientApi(Iterable<User> users, Map<String, String> workspaceNames, Map<String, Integer> sessionCounts) {
         ClientApiUsers clientApiUsers = new ClientApiUsers();
         for (User user : users) {
-            clientApiUsers.getUsers().add(toClientApi(user, workspaceNames));
+            clientApiUsers.getUsers().add(toClientApi(user, workspaceNames, sessionCounts));
         }
         return clientApiUsers;
     }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiUser.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiUser.java
@@ -17,6 +17,7 @@ public class ClientApiUser implements ClientApiObject {
     private String csrfToken;
     private Date currentLoginDate;
     private Date previousLoginDate;
+    private Integer sessionCount;
     private Set<String> privileges = new HashSet<String>();
     private JsonNode uiPreferences;
     private List<String> authorizations = new ArrayList<String>();
@@ -62,6 +63,14 @@ public class ClientApiUser implements ClientApiObject {
 
     public void setCurrentWorkspaceId(String currentWorkspaceId) {
         this.currentWorkspaceId = currentWorkspaceId;
+    }
+
+    public Integer getSessionCount() {
+        return sessionCount;
+    }
+
+    public void setSessionCount(Integer sessionCount) {
+        this.sessionCount = sessionCount;
     }
 
     public UserStatus getStatus() {

--- a/web/plugins/admin-user-tools/src/main/resources/org/visallo/web/adminUserTools/ActiveUserList.jsx
+++ b/web/plugins/admin-user-tools/src/main/resources/org/visallo/web/adminUserTools/ActiveUserList.jsx
@@ -30,7 +30,8 @@ define([
                 error: null
             });
             this.dataRequest('user', 'search', {
-                status: 'ACTIVE'
+                status: 'ACTIVE',
+                includeSessionCount: true
             })
                 .then(users => {
                     this.setState({
@@ -67,25 +68,33 @@ define([
                 <div>
                     <ul className="nav-list nav">
                         {this.state.users.map(user => {
-                            console.log(user);
-                            return (<li className="highlight-on-hover" key={user.id}>
-                                <span className="nav-list-title">{user.userName}</span>
+                            const {
+                                id, userName, displayName,
+                                sessionCount, currentLoginDate,
+                                currentWorkspaceName, currentWorkspaceId
+                            } = user;
+
+                            return (<li className="highlight-on-hover" key={id}>
+                                <span
+                                    title={i18n('admin.user.activeList.sessionCount')}
+                                    class="badge pull-right">{isNaN(sessionCount) ? '?' : sessionCount}</span>
+                                <span className="nav-list-title">{userName}</span>
                                 <ul className="inner-list">
                                     <label className="nav-header">
                                         {i18n('admin.user.activeList.userId')}
-                                        <span>{user.id}</span>
+                                        <span>{id}</span>
                                     </label>
                                     <label className="nav-header">
                                         {i18n('admin.user.activeList.displayName')}
-                                        <span>{user.displayName}</span>
+                                        <span>{displayName}</span>
                                     </label>
                                     <label className="nav-header">
                                         {i18n('admin.user.activeList.loginDate')}
-                                        <span>{F.date.dateTimeString(user.currentLoginDate)}</span>
+                                        <span>{F.date.dateTimeString(currentLoginDate)}</span>
                                     </label>
                                     <label className="nav-header">
                                         {i18n('admin.user.activeList.currentWorkspace')}
-                                        <span>{user.currentWorkspaceName} ({user.currentWorkspaceId})</span>
+                                        <span>{currentWorkspaceName} ({currentWorkspaceId})</span>
                                     </label>
                                 </ul>
                             </li>);

--- a/web/plugins/admin-user-tools/src/main/resources/org/visallo/web/adminUserTools/messages.properties
+++ b/web/plugins/admin-user-tools/src/main/resources/org/visallo/web/adminUserTools/messages.properties
@@ -15,6 +15,7 @@ admin.user.editor.deleteUser=Delete User
 admin.user.activeList=Active Users
 admin.user.activeList.subtitle=Display a list of active users
 admin.user.activeList.refresh=Refresh
+admin.user.activeList.sessionCount=Active Session Count
 admin.user.activeList.loading=Loading Active Users...
 admin.user.activeList.userList=Active Users
 admin.user.activeList.error=Error loading

--- a/web/war/src/main/webapp/js/data/web-worker/services/user.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/user.js
@@ -97,6 +97,9 @@ define(['../util/ajax', '../store', '../store/user/actions-impl'], function(ajax
             if (options.status) {
                 data.status = options.status;
             }
+            if (options.includeSessionCount) {
+                data.includeSessionCount = true
+            }
             if (options.userIds) {
                 if (!_.isArray(options.userIds)) {
                     returnSingular = true;


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Allows visibility to why a user is active. Probably want an admin tool to reset this as it can get out of sync if server restarts. We probably need to come up with a better way to fix these issues. 

**I noticed my user had a count of 64 because restarting the server while logged in would cause it to never decrement the count. Should we clear all on server startup? and how to do that in a cluster?**

Testing Instructions: Open Admin-> Active User List, should see badge with session count next to users

Points of Regression: Admin user list, any other user search screens (sharing, etc)

CHANGELOG
Added: Session count added in admin active user list
