### PR TITLE
Fix Saved Search Aggregation Configuration

### DIFF
--- a/web/war/src/main/webapp/js/search/dashboard/aggregation.js
+++ b/web/war/src/main/webapp/js/search/dashboard/aggregation.js
@@ -427,15 +427,7 @@ define([
         this.onFilterProperties = function(event, data) {
             if ($(event.target).is('.property-select')) return;
 
-            if (!data || _.isEmpty(data.properties)) {
-                this.filteredProperties = null;
-            } else {
-                this.filteredProperties = data.properties;
-            }
-
-            this.$node.find('.property-select').trigger(event.type, {
-                properties: this.filteredProperties
-            });
+            this.$node.find('.property-select').trigger(event.type, data)
         };
 
         this.attachPropertySelection = function(node, options) {

--- a/web/war/src/main/webapp/js/search/dashboard/configure.js
+++ b/web/war/src/main/webapp/js/search/dashboard/configure.js
@@ -145,12 +145,9 @@ define([
         this.updateAggregationVisibility = function(preventTrigger) {
             var self = this,
                 searchId = this.attr.item.configuration.searchId,
-                conceptType = searchId ? this.searchesById[searchId].parameters.conceptType : null;
+                conceptId = searchId ? this.searchesById[searchId].parameters.conceptType : null;
 
-            return Promise.all([
-                Promise.require('search/dashboard/aggregation'),
-                conceptType && this.dataRequest('ontology', 'propertiesByConceptId', conceptType)
-            ]).then(function([Aggregation, propertiesByConceptId]) {
+            return Promise.require('search/dashboard/aggregation').then(function(Aggregation) {
                 const node = self.select('aggregationSectionSelector');
                 let aggregations;
                 if (self.aggregations) {
@@ -161,12 +158,8 @@ define([
                 Aggregation.attachTo(node.teardownComponent(Aggregation), {
                     aggregations
                 })
-                if (propertiesByConceptId) {
-                    node.trigger('filterProperties', {
-                        properties: propertiesByConceptId.list.filter(function(property) {
-                            return !property.dependentPropertyIris
-                        })
-                    });
+                if (conceptId) {
+                    node.trigger('filterProperties', { conceptId });
                 }
                 var aggregation = _.first(self.aggregations);
                 return self.updateAggregationDependents(aggregation && aggregation.type, preventTrigger);
@@ -240,7 +233,7 @@ define([
             var self = this,
                 item = this.attr.item,
                 searchId = this.attr.item.configuration.searchId,
-                conceptType = searchId ? this.searchesById[searchId].parameters.conceptType : null;
+                conceptId = searchId ? this.searchesById[searchId].parameters.conceptType : null;
 
             if (type) {
                 if (item.configuration.searchParameters) {
@@ -257,9 +250,8 @@ define([
 
                 Promise.all([
                     this.dataRequest('ontology', 'properties'),
-                    Promise.require('search/sort'),
-                    conceptType && this.dataRequest('ontology', 'propertiesByConceptId', conceptType)
-                ]).spread(function(properties, Sort, propertiesByConceptId) {
+                    Promise.require('search/sort')
+                ]).spread(function(properties, Sort) {
                     var node = self.$node.find('.sort').show(),
                         sortFieldsNode = node.find('.sort-fields');
 
@@ -267,12 +259,8 @@ define([
                         sorts: self.sortFields
                     });
 
-                    if (propertiesByConceptId) {
-                        sortFieldsNode.trigger('filterProperties', {
-                            properties: propertiesByConceptId.list.filter(function(property) {
-                                return !property.dependentPropertyIris
-                            })
-                        });
+                    if (conceptId) {
+                        sortFieldsNode.trigger('filterProperties', { conceptId });
                     }
                 });
                 this.aggregationField = null;


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

The property selection was broken allowing for selection of properties whose datatype doesn't support the aggregation. Switch to whitelist of datatypes for each aggregation type, and fix the filters passed to the updated flight shim to new react selection component.

Testing Instructions: Shouldn't be able to create "Count" or "Histogram" aggregations for geolocations. Geolocations should be selectable for "Geo-Coordinate Cluster"

Points of Regression: Saved Search Card Aggregation Configuration

CHANGELOG
Fixed: Saved search aggregation configuration would allow selection of incompatible properties.