### PR TITLE
fix visibility property popover not displaying for read only privilege users

### DIFF
--- a/web/war/src/main/webapp/js/detail/properties/properties.js
+++ b/web/war/src/main/webapp/js/detail/properties/properties.js
@@ -788,7 +788,8 @@ define([
                             !property.hideInfo && (
                                 isEditable ||
                                 ontologyProperty.searchable ||
-                                hasVisibleMetadata)
+                                hasVisibleMetadata ||
+                                visibility)
                         ));
 
                         if (displayType && F.vertex.properties[displayType]) {


### PR DESCRIPTION
4.0.1 PR: https://github.com/visallo/visallo/pull/1610

- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Make sure all users are able to see the visibility "i" popover

Points of Regression: property info popover

CHANGELOG
Fixed: Read only privilege users not being able to see entity level metadata

  
  