### PR TITLE
Fix default state of showing only user visible properties

### DIFF
--- a/web/war/src/main/webapp/js/search/sort.js
+++ b/web/war/src/main/webapp/js/search/sort.js
@@ -101,7 +101,7 @@ define([
                 rollupCompound: false,
                 hideCompound: true,
                 placeholder: i18n('search.sort.placeholder'),
-                filter: this.filter
+                filter: { ...this.filter, userVisible: true }
             });
         };
 


### PR DESCRIPTION
4.0.1 PR: https://github.com/visallo/visallo/pull/1613

- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Testing Instructions:
- Make sure sort search filter list doesn't show non user visible properties
- Make sure dashboard card configuration sort list doesn't show non user visible properties

Points of Regression: Sort properties list

CHANGELOG
Fixed: Sort on dashboard card showing non-user visible properties

  
  