### PR TITLE
Add heatmap layer that displays same features as cluster source

### DIFF
--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
@@ -103,13 +103,16 @@ define([
                                 this.olEvents.concat(initializer.addEvents(map, layerWithSource, handlers));
                             }
 
-                            const config = nextProps.layerConfig && nextProps.layerConfig[layerWithSource.layer.get('id')];
-                            if (config) {
-                                layerHelpers.setLayerConfig(config, layerWithSource.layer);
-                            }
+                            const layers = layerWithSource.layers || [layerWithSource.layer];
+                            layers.forEach(layer => {
+                                const config = nextProps.layerConfig && nextProps.layerConfig[layer.get('id')];
+                                if (config) {
+                                    layerHelpers.setLayerConfig(config, layer);
+                                }
 
-                            newLayersWithSources[layerId] = layerWithSource;
-                            nextLayers.push(layerWithSource.layer);
+                                newLayersWithSources[layerId] = layerWithSource;
+                                nextLayers.push(layer);
+                            })
                         } else {
                             console.warn('Sources present for layer: ' + layerId + ', but no layer type defined for: ' + type);
                         }
@@ -374,7 +377,8 @@ define([
             } else {
                 extent = ol.extent.createEmpty();
                 map.getLayers().forEach(layer => {
-                    const source = layersWithSources.cluster.layer === layer ? layersWithSources.cluster.source : layer.getSource();
+                    const source = layersWithSources.cluster.layers.includes(layer) ?
+                        layersWithSources.cluster.source : layer.getSource();
 
                     if (layer.getVisible() && _.isFunction(source.getExtent)) {
                         ol.extent.extend(extent, source.getExtent());
@@ -473,12 +477,14 @@ define([
                 }
 
                 layersWithSources[layerId] = layerWithSource;
-                map.addLayer(layerWithSource.layer);
-
-                const config = layerConfig && layerConfig[layerWithSource.layer.get('id')];
-                if (config) {
-                    layerHelpers.setLayerConfig(config, layerWithSource.layer);
-                }
+                const layers = layerWithSource.layers || [layerWithSource.layer];
+                layers.forEach(layer => {
+                    map.addLayer(layer);
+                    const config = layerConfig && layerConfig[layer.get('id')];
+                    if (config) {
+                        layerHelpers.setLayerConfig(config, layer);
+                    }
+                })
             };
 
             _.mapObject(layerExtensions, (e, layerId) => {


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88


<img width="838" alt="screen shot 2018-01-05 at 1 03 50 pm" src="https://user-images.githubusercontent.com/7098/34623948-f27e232c-f218-11e7-8fbf-78a8eb150546.png">

Testing Instructions: 
Heatmap layer is below cluster layer and disabled by default. Selection works, although no selection style.

Note: There is performance degradation after enabled. It does a post render blend to create the effect, which can be slow on large displays / lots of features

Points of Regression: Map, map layers

CHANGELOG
Added: New map product layer "Heatmap" that displays the cluster pins as a heatmap.

  