### PR TITLE
Update propForm when choosing entity to resolve a property on

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -216,6 +216,7 @@ detail.text.terms.form.resolve.existing=Resolve to Existing Entity
 detail.text.terms.form.resolve.new=Resolve to New Entity
 detail.text.terms.form.resolve.search=Search for Entities
 detail.text.terms.form.resolve.create=Create {0} Entity
+detail.text.terms.form.resolve.property=Set Property with Justification
 detail.text.terms.form.resolve.placeholder=Resolve To…
 detail.text.terms.form.resolve.button=Resolve
 detail.text.terms.form.unresolve=Unresolve Entity

--- a/web/war/src/main/webapp/js/components/element/ElementSelector.jsx
+++ b/web/war/src/main/webapp/js/components/element/ElementSelector.jsx
@@ -21,24 +21,29 @@ define([
             onCreateNewElement: PropTypes.func,
             searchOptions: PropTypes.object
         },
+
         getDefaultProps() {
             return { searchOptions: {} };
         },
+
         getInitialState() {
             return { options: [], isLoading: false };
         },
+
         componentDidMount() {
             this.onInputChange = _.debounce(this.onInputChange, 250);
             const { value } = this.props;
             if (value) {
-                this.searchForElements(value)
+                this.searchForElements(value, true)
             }
         },
+
         componentWillUnmount() {
             if (this.request) {
                 this.request.cancel();
             }
         },
+
         render() {
             const { value: initialValue, creatable, ...rest } = this.props;
             const { value, options, isLoading } = this.state;
@@ -63,7 +68,8 @@ define([
                 />
             )
         },
-        searchForElements(input) {
+
+        searchForElements(input, autoSelect = false) {
             const { searchOptions, filterResultsToTitleField } = this.props;
             const query = `${input}*`;
 
@@ -109,16 +115,21 @@ define([
                         });
                     }
 
-                    const startIndex = creatable ? 1 : 0;
-                    let toSelect;
-                    if (options.length > startIndex) {
-                        toSelect = options[startIndex];
-                    } else if (creatable) {
-                        toSelect = options[0];
-                    }
                     this.setState({ options, isLoading: false });
-                    if (toSelect) {
-                        this.onChange(toSelect);
+
+                    if (autoSelect) {
+                        const startIndex = creatable ? 1 : 0;
+                        let toSelect;
+
+                        if (options.length > startIndex) {
+                            toSelect = options[startIndex];
+                        } else if (creatable) {
+                            toSelect = options[0];
+                        }
+
+                        if (toSelect) {
+                            this.onChange(toSelect);
+                        }
                     }
                 })
                 .catch(error => {
@@ -126,9 +137,11 @@ define([
                     this.setState({ isLoading: false })
                 })
         },
+
         onInputChange(input) {
             this.searchForElements(input)
         },
+
         onChange(option) {
             if (option) {
                 this.setState({ value: option.id })
@@ -149,6 +162,7 @@ define([
                 }
             }
         },
+
         elementValueRenderer(option) {
             const { creatable, input } = option;
             if (creatable) {

--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -8,8 +8,7 @@ define([
     'util/withTeardown',
     'util/vertex/vertexSelect',
     'util/vertex/formatters',
-    'util/withDataRequest',
-    'util/acl'
+    'util/withDataRequest'
 ], function(
     require,
     defineComponent,
@@ -20,8 +19,7 @@ define([
     withTeardown,
     VertexSelector,
     F,
-    withDataRequest,
-    acl
+    withDataRequest
 ) {
     'use strict';
 
@@ -122,6 +120,8 @@ define([
             }
 
             const propertyNode = this.select('propertyListSelector').show();
+            propertyNode.teardownAllComponents();
+
             propertyNode.one('rendered', () => {
                 this.on('opened', () => {
                     propertyNode.find('input').focus()
@@ -130,6 +130,7 @@ define([
                     this.manualOpen();
                 })
             });
+
             PropertySelector.attachTo(propertyNode, {
                 filter: {
                     conceptId: this.attr.data.conceptType,

--- a/web/war/src/main/webapp/js/detail/text/popover/forms/Property.jsx
+++ b/web/war/src/main/webapp/js/detail/text/popover/forms/Property.jsx
@@ -1,13 +1,11 @@
 define([
     'create-react-class',
     'prop-types',
-    'components/Attacher',
-    'components/Alert'
+    'components/Attacher'
 ], function(
     createReactClass,
     PropTypes,
-    Attacher,
-    Alert) {
+    Attacher) {
 
     const Property = createReactClass({
         propTypes: {
@@ -16,10 +14,12 @@ define([
             attemptToCoerceValue: PropTypes.string,
             sourceInfo: PropTypes.object
         },
+
         getInitialState() {
             return {};
         },
-        shouldComponentUpdate(nextProps) {
+
+        shouldComponentUpdate(nextProps, nextState) {
             if (this._ref && nextProps.error && nextProps.error !== this.props.error) {
                 const $node = $(this._ref.attacher._node)
                 $node.trigger('propertyerror', { error: nextProps.error })
@@ -28,23 +28,24 @@ define([
             // Work around flight component not handling state changes well
             return false;
         },
+
         render() {
             const { onCancel, onSave, attemptToCoerceValue, sourceInfo } = this.props;
             const { element, property } = this.state;
 
             return (
                 <div className="form" style={{padding: 0}}>
-
-                    <h1 style={{marginBottom: '-0.3em', padding: '0.5em 1em 0'}}>Set Property with Justification</h1>
-
+                    <h1 style={{marginBottom: '-0.3em', padding: '0.5em 1em 0'}}>
+                        { i18n('detail.text.terms.form.resolve.property') }
+                    </h1>
                     <Attacher
                         componentPath="detail/dropdowns/propertyForm/propForm"
                         behavior={{
-                            propFormPropertyChanged: (inst, {property}) => {
+                            propFormPropertyChanged: (inst, { property }) => {
                                 this.setState({ property })
                             },
-                            propFormVertexChanged: (inst, {vertex}) => {
-                                this.setState({ element })
+                            propFormVertexChanged: (inst, { vertex }) => {
+                                this.setState({ element: vertex })
                             },
                             addProperty: (inst, { node, ...data }) => {
                                 const { element, property } = data;
@@ -61,7 +62,8 @@ define([
                         allowEditProperty={false}
                         disableDropdownFeatures={true}
                         attemptToCoerceValue={attemptToCoerceValue}
-                        sourceInfo={sourceInfo} />
+                        sourceInfo={sourceInfo}
+                    />
                 </div>
             )
         }


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Teardown property selection field in propForm before setting up a new one. Fixes issue when selecting a new vertex the property selection field is not given the new concept type to limit by.

Points of Regression: propForm (adding/editing properties of an element in the inspector), resolving entities

CHANGELOG
Fixed: When resolving text to a property on an entity, the correct entity type and available properties for that entity type are shown.
