### PR TITLE
Fix product error after case deletion

### DIFF
--- a/web/war/src/main/webapp/js/product/ProductDetail.jsx
+++ b/web/war/src/main/webapp/js/product/ProductDetail.jsx
@@ -13,7 +13,8 @@ define([
             }).isRequired,
             extension: PropTypes.shape({
                 componentPath: PropTypes.string.isRequired
-            }).isRequired
+            }).isRequired,
+            workspace: PropTypes.object
         },
 
         getInitialState: () => ({ Component: null }),
@@ -28,11 +29,11 @@ define([
 
         render() {
             const { Component } = this.state;
-            const { product, editable, hasPreview } = this.props;
+            const { product, editable, hasPreview, workspace } = this.props;
             const { extendedData, title } = product;
 
             return (
-                Component && extendedData ? (
+                Component && extendedData && workspace ? (
                     <ErrorBoundary>
                         <Component product={this.props.product} hasPreview={hasPreview}></Component>
                     </ErrorBoundary>

--- a/web/war/src/main/webapp/js/product/ProductDetailContainer.jsx
+++ b/web/war/src/main/webapp/js/product/ProductDetailContainer.jsx
@@ -41,6 +41,8 @@ define([
             const product = productSelectors.getProduct(state);
             const { loading, loaded } = productSelectors.getStatus(state);
             const extensions = registry.extensionsForPoint('org.visallo.workproduct');
+            const workspace = state.workspace.currentId ?
+                state.workspace.byId[state.workspace.currentId] : null;
 
             if (product) {
                 const productExtensions = _.where(extensions, { identifier: product.kind });
@@ -55,11 +57,10 @@ define([
                     padding: state.panel.padding,
                     product,
                     hasPreview: Boolean(productSelectors.getPreviewHash(state)),
-                    extension: productExtensions[0]
+                    extension: productExtensions[0],
+                    workspace
                 }
             } else if (extensions.length && loaded) {
-                const workspace = state.workspace.currentId ?
-                    state.workspace.byId[state.workspace.currentId] : null;
                 const user = state.user.current;
                 return {
                     padding: state.panel.padding,
@@ -67,7 +68,8 @@ define([
                     extensions,
                     editable: workspace && user ?
                         workspace.editable && user.privileges.includes('EDIT') :
-                        false
+                        false,
+                    workspace
                 };
             }
             return {}


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

If there is not a current workspace show the ProductDetailEmpty component, fixes issue where an already selected product can error when trying to access the workspace object in between the deletion of a case and selection/creation of a new one

Points of Regression: selection and loading of products, empty product screen

CHANGELOG
Fixed: If you were on a graph work product and only had a single case, deleting the case would cause the product fullscreen view to remain blank.
