### PR TITLE
Fix partial cluster selection on the map

### DIFF
--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
@@ -137,7 +137,7 @@ define([
 
         render() {
             const { viewport, generatePreview } = this.state;
-            const { product, registry, panelPadding, focused, layerConfig, setLayerOrder, onSelectElements } = this.props;
+            const { product, registry, panelPadding, focused, layerConfig, setLayerOrder, onAddSelection, onSelectElements } = this.props;
             const { source: baseSource, sourceOptions: baseSourceOptions, ...config } = mapConfig();
             const layerExtensions = _.indexBy(registry['org.visallo.map.layer'], 'id');
 
@@ -161,6 +161,7 @@ define([
                         onPan={this.onViewport}
                         onZoom={this.onViewport}
                         onContextTap={this.onContextTap}
+                        onAddSelection={onAddSelection}
                         onSelectElements={onSelectElements}
                         onMouseOver={this.onMouseOver}
                         onMouseOut={this.onMouseOut}

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
@@ -66,6 +66,7 @@ define([
         (dispatch, props) => {
             return {
                 onClearSelection: () => dispatch(selectionActions.clear()),
+                onAddSelection: (selection) => dispatch(selectionActions.add(selection)),
                 onSelectElements: (selection) => dispatch(selectionActions.set(selection)),
                 onSelectAll: (id) => dispatch(productActions.selectAll(id)),
 


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Points of Regression: elements on the map selection/focus

CHANGELOG
Fixed: Clicking or shift+clicking a cluster that is partially selected will select all of the cluster's contents.
Fixed: On the map, shift+clicking another cluster/pin while a cluster is partially selected would select all of the cluster's contents.
Changed: Shift+clicking clusters on the map will add them to the selection. Cmd+click or ctrl+click, on Mac or Windows respectively, will toggle the cluster's selection state. This is now consistent with graph behavior.

