### PR TITLE
Fix diff action selection when users don't have ONTOLOGY_PUBLISH

### DIFF
--- a/web/war/src/main/webapp/js/workspaces/diff/DiffPanel.jsx
+++ b/web/war/src/main/webapp/js/workspaces/diff/DiffPanel.jsx
@@ -89,13 +89,15 @@ define([
                 publishCount,
                 undoCount,
                 totalCount,
+                ontologyRequiredCount,
                 publishing,
                 undoing,
                 onApplyPublishClick,
                 onApplyUndoClick
             } = this.props;
-            const publishingAll = publishCount === totalCount;
-            const undoingAll = undoCount === totalCount;
+            const totalPublishCount = Privileges.missingONTOLOGY_PUBLISH ? (totalCount - ontologyRequiredCount) : totalCount;
+            const publishingAll = publishCount > 0 && publishCount === totalPublishCount;
+            const undoingAll = undoCount > 0 && undoCount === totalCount;
 
             return (
               <div className="diff-header">
@@ -171,7 +173,6 @@ define([
         renderDiffActions: function(id, { publish, undo, requiresOntologyPublish }) {
             const { publishing, undoing, onPublishClick, onUndoClick } = this.props;
             const applying = publishing || undoing;
-
             const disabledBecauseOntologyChange = requiresOntologyPublish && Privileges.missingONTOLOGY_PUBLISH;
 
             return (
@@ -190,7 +191,7 @@ define([
                                 {i18n('workspaces.diff.button.publish')}
                             </button>
                         ) : null}
-                        {Privileges.canEDIT && !disabledBecauseOntologyChange ? (
+                        {Privileges.canEDIT ? (
                             <button className={
                                 classNames('btn', 'btn-mini', 'undo', 'requires-EDIT', {
                                     'btn-danger': undo


### PR DESCRIPTION
- [x] joeferner
- [ ] mwizeman joeybrk372 jharwig sfeng88

Points of Regression: none

CHANGELOG
Changed: Editors and publishers without ontology publish privileges can still undo any diff that requires a schema change.
Fixed:  Publish All button selected property diffs that required schema changes even if you didn't have the ontology publish privilege, if the entity type was already published.
Fixed: Publish/Undo All buttons not accounting for diffs that required schema changes when deciding if all changes are in the same state.
