### PR TITLE
Fix heatmap layer selecting when other layers hidden

### DIFF
--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/layers/mapLayers.less
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/layers/mapLayers.less
@@ -115,6 +115,15 @@
   input {
     flex: 0 0 auto;
     margin: 0.5em;
+    position: relative;
+    &:before {
+        content: '';
+        position: absolute;
+        top:-0.8em;
+        bottom:-0.8em;
+        left:-0.5em;
+        right:-0.5em;
+    }
   }
 
   .layer-title {

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/util/layerHelpers.js
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/util/layerHelpers.js
@@ -89,6 +89,7 @@ define([
                     id: 'heatmap_cluster',
                     label: 'Heatmap',
                     type: 'cluster_heatmap',
+                    defaultVisibility: false,
                     source
                 })
 
@@ -523,7 +524,11 @@ define([
     }
 
     function setLayerConfig(config = {}, layer) {
-        const { visible = true, opacity = 1, zIndex = 0, ...properties } = config;
+        let defaultVisibility = layer.get('defaultVisibility')
+        if (!_.isBoolean(defaultVisibility)) {
+            defaultVisibility = true;
+        }
+        const { visible = defaultVisibility, opacity = 1, zIndex = 0, ...properties } = config;
 
         _.mapObject(properties, (value, key) => {
             if (value === null) {


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

* Heatmap layer needed a way to set it was hidden by default
* Also adds some more clickable area around the visibility checkbox in layer
list

Points of Regression: Map layer list

NO CHANGELOG heat map added in 4.1