### PR TITLE
Allow multiple values in structured ingest

### DIFF
--- a/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/util/GraphBuilderParserHandler.java
+++ b/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/util/GraphBuilderParserHandler.java
@@ -423,7 +423,7 @@ public class GraphBuilderParserHandler extends BaseStructuredFileParserHandler {
                     .stream()
                     .sorted(String::compareToIgnoreCase)
                     .forEach(s -> {
-                        hasher.putString(row.get(s).toString(), Charsets.UTF_8).putString("|");
+                        hasher.putString(prepareValueForHash(row.get(s)), Charsets.UTF_8).putString("|");
                     });
 
             for (PropertyMapping mapping : vertexMapping.propertyMappings) {
@@ -447,6 +447,10 @@ public class GraphBuilderParserHandler extends BaseStructuredFileParserHandler {
         }
 
         return vertexId;
+    }
+
+    private String prepareValueForHash(Object obj) {
+        return String.valueOf(obj).trim().toLowerCase();
     }
 
     /**
@@ -483,8 +487,7 @@ public class GraphBuilderParserHandler extends BaseStructuredFileParserHandler {
         Object propertyValue = propertyMapping.decodeValue(row);
         if (propertyValue != null) {
             Hasher hasher = Hashing.sha1().newHasher();
-            hasher.putString(String.valueOf(propertyValue), Charsets.UTF_8);
-
+            hasher.putString(prepareValueForHash(propertyValue), Charsets.UTF_8);
             String keySuffix = hasher.hash().toString();
             m.addPropertyValue(MULTI_KEY + keySuffix, propertyMapping.name, propertyValue, metadata, propertyVisibility);
         }

--- a/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/util/GraphBuilderParserHandler.java
+++ b/web/plugins/structured-ingest/core/src/main/java/org/visallo/web/structuredingest/core/util/GraphBuilderParserHandler.java
@@ -39,13 +39,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.visallo.core.model.properties.VisalloProperties.VISIBILITY_JSON_METADATA;
 
 public class GraphBuilderParserHandler extends BaseStructuredFileParserHandler {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(GraphBuilderParserHandler.class);
     public static final Long MAX_DRY_RUN_ROWS = 50000L;
-    private static final String MULTI_KEY = "SFIMPORT";
+    private static final String MULTI_KEY = "SFIMPORT:";
     private static final String SKIPPED_VERTEX_ID = "SKIPPED_VERTEX";
 
     private final Graph graph;
@@ -483,7 +482,11 @@ public class GraphBuilderParserHandler extends BaseStructuredFileParserHandler {
 
         Object propertyValue = propertyMapping.decodeValue(row);
         if (propertyValue != null) {
-            m.addPropertyValue(MULTI_KEY, propertyMapping.name, propertyValue, metadata, propertyVisibility);
+            Hasher hasher = Hashing.sha1().newHasher();
+            hasher.putString(String.valueOf(propertyValue), Charsets.UTF_8);
+
+            String keySuffix = hasher.hash().toString();
+            m.addPropertyValue(MULTI_KEY + keySuffix, propertyMapping.name, propertyValue, metadata, propertyVisibility);
         }
     }
 }

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/css/style.css
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/css/style.css
@@ -11,6 +11,7 @@
   transform: translate(-50%, -50%);
   width: auto;
   max-width: 90vw;
+  min-width: 500px;
 }
 
 .com-visallo-csv table {
@@ -217,6 +218,9 @@
 }
 .com-visallo-csv section .form-container .form-row > * {
   flex: 1 1 auto;
+}
+.com-visallo-csv section .form-container .form-row > *:first-child {
+  flex: 2 1 auto;
 }
 .com-visallo-csv section .form-container .form-row > *:last-child {
   margin-left: 0.5em;

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/messages.properties
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/messages.properties
@@ -15,6 +15,7 @@ csv.file_import.mapping.save=Save
 csv.file_import.mapping.import.preview=Preview
 csv.file_import.mapping.import.ingest=Import
 csv.file_import.mapping.import.entity.unique.column.identifier=Use this column as unique identifier for this entity
+csv.file_import.mapping.import.entity.unique.column.identifier.add=Add this column to the unique identifier for this entity
 csv.file_import.mapping.properties.placeholder=Choose Property...
 csv.file_import.mapping.error.duplicate.property=Unable to map this property to {0} in multiple columns.
 csv.file_import.entities.new=New Entity

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/templates/columnEditor.hbs
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/templates/columnEditor.hbs
@@ -21,5 +21,8 @@
 </div>
 <div class="field-error"></div>
 <div class="aux_fields"></div>
-<label class="identifier"><input type="checkbox" name="isIdentifier" style="margin:0" /> {{ i18n 'csv.file_import.mapping.import.entity.unique.column.identifier' }}</label>
+<label class="identifier">
+  <input type="checkbox" name="isIdentifier" style="margin:0" />
+  <span class="identifier_text">{{ i18n 'csv.file_import.mapping.import.entity.unique.column.identifier' }}</span>
+</label>
 


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Each property key is a hash of the value

* Fix initial width to minimum level
* Change unique identifier wording if appending
* Fix some js errors
* Fix multiple unnecessary renders

Points of Regression: Structured import

CHANGELOG
Added: Structured file import (CSV,Excel) can now import multiple values of the same property for an entity
Changed: For structured import with few columns, make the modal window big enough to work with
