### PR TITLE
Don't clear search hits count when closing the search pane

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -357,9 +357,6 @@ define([
             if (data.name === 'search' && this.$node.closest('.visible').length === 0) {
                 this.$node.find('.advanced-search-type-results').hide();
             }
-            if (this.searchType && this.searchType === SEARCH_TYPES[0]) {
-                this.select('hitsSelector').empty();
-            }
         };
 
         this.onSearchTypeLoaded = function() {
@@ -859,11 +856,10 @@ define([
         }
 
         this.render = function() {
-            var self = this,
-                advancedSearch = registry.extensionsForPoint('org.visallo.search.advanced');
+            const extensions = registry.extensionsForPoint('org.visallo.search.advanced');
 
             this.$node.html(template({
-                advancedSearch: advancedSearch,
+                advancedSearch: extensions,
                 types: SEARCH_TYPES.map(function(type, i) {
                     return {
                         cls: type.toLowerCase(),


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

CHANGELOG
Fixed: Number of search results would disappear when closing and reopening the search pane, but the results would still be displayed.
