### PR TITLE
Don't create detail previews for vertices inside collapsed nodes

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -658,6 +658,9 @@ define([
                 Promise.require('util/popovers/detail/detail'),
                 F.vertex.getVertexIdsFromDataEventOrCurrentSelection(data, { async: true })
             ]).spread((DetailPopover, ids) => {
+                const { productElementIds, rootId } = this.props;
+                ids = ids.filter(id => productElementIds.vertices[id].parent === rootId);
+
                 if (!this.detailPopoversMap) {
                     this.detailPopoversMap = {};
                 }


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

CHANGELOG
Fixed: If you showed vertex previews with alt+P while collapsed nodes were in your selection, the previews for the contents of the collapsed nodes would all appear at the top left corner of the screen.
