### PR TITLE
Call shutdown on JVM exit/SIGTERM to give everyone a chance to clean up

### DIFF
--- a/core/core/src/main/java/org/visallo/core/cmdline/CommandLineTool.java
+++ b/core/core/src/main/java/org/visallo/core/cmdline/CommandLineTool.java
@@ -59,17 +59,19 @@ public abstract class CommandLineTool {
         try {
             LOGGER = VisalloLoggerFactory.getLogger(CommandLineTool.class, "cli");
             final Thread mainThread = Thread.currentThread();
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    willExit = true;
-                    try {
-                        mainThread.join(1000);
-                    } catch (InterruptedException e) {
-                        // nothing useful to do here
-                    }
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                willExit = true;
+
+                if (frameworkInitialized) {
+                    shutdown();
                 }
-            });
+
+                try {
+                    mainThread.join(1000);
+                } catch (InterruptedException e) {
+                    // nothing useful to do here
+                }
+            }));
 
             try {
                 jCommander = parseArguments(args);

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyThreadedWrapper.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyThreadedWrapper.java
@@ -32,7 +32,7 @@ public class GraphPropertyThreadedWrapper implements Runnable {
     private Counter processingCounter;
     private Counter totalErrorCounter;
     private Timer processingTimeTimer;
-    private boolean stopped;
+    private volatile boolean stopped;
     private final Queue<Work> workItems = new LinkedList<>();
     private final Queue<WorkResult> workResults = new LinkedList<>();
     private MetricsManager metricsManager;

--- a/core/core/src/main/java/org/visallo/core/util/ShutdownService.java
+++ b/core/core/src/main/java/org/visallo/core/util/ShutdownService.java
@@ -13,8 +13,15 @@ import java.util.List;
 public class ShutdownService {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ShutdownService.class);
     private LinkedHashSet<ShutdownListener> shutdownListeners = new LinkedHashSet<>();
+    private boolean shutdownCalled;
 
-    public void shutdown() {
+    public synchronized void shutdown() {
+        if (shutdownCalled) {
+            LOGGER.debug("shutdown already called");
+            return;
+        }
+        shutdownCalled = true;
+
         // shutdown in reverse order to better handle dependencies
         List<ShutdownListener> shutdownListenersList = Lists.reverse(new ArrayList<>(shutdownListeners));
         for (ShutdownListener shutdownListener : shutdownListenersList) {


### PR DESCRIPTION
- [x] joeferner
- [x] mwizeman joeybrk372 jharwig sfeng88

Points of Regression:
- Send `SIGTERM` or docker stop on a Visallo command line program, check that it calls the shutdown hooks

CHANGELOG
Added: Call shutdown on JVM exit/SIGTERM to give everyone a chance to clean up
